### PR TITLE
Make the etcd repo used by confd configurable.

### DIFF
--- a/master/confd.sh
+++ b/master/confd.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /confd -confdir=/ -debug -interval=5 -watch -verbose >>/var/log/calico/confd.log 2>&1
+exec /confd -confdir=/ -debug -interval=5 -watch -verbose --nodes=${ETCD_IP} >>/var/log/calico/confd.log 2>&1

--- a/master/confd.sh
+++ b/master/confd.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /confd -confdir=/ -debug -interval=5 -watch -verbose --nodes=${ETCD_IP} >>/var/log/calico/confd.log 2>&1
+exec /confd -confdir=/ -debug -interval=5 -watch -verbose -node ${ETCD_IP} >>/var/log/calico/confd.log 2>&1

--- a/master/rc.local
+++ b/master/rc.local
@@ -4,4 +4,4 @@ date > /tmp/boottime.txt
 
 # Run Confd in onetime mode, to ensure that we have a working config in place to allow bird and
 # felix to start.
-./confd -confdir=. -onetime
+./confd -confdir=. -onetime -node ${ETCD_IP}

--- a/node/confd.sh
+++ b/node/confd.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /confd -confdir=/ -debug -interval=5 -watch -verbose >>/var/log/calico/confd.log 2>&1
+exec /confd -confdir=/ -debug -interval=5 -watch -verbose --nodes=${ETCD_IP} >>/var/log/calico/confd.log 2>&1

--- a/node/confd.sh
+++ b/node/confd.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /confd -confdir=/ -debug -interval=5 -watch -verbose --nodes=${ETCD_IP} >>/var/log/calico/confd.log 2>&1
+exec /confd -confdir=/ -debug -interval=5 -watch -verbose -node ${ETCD_IP} >>/var/log/calico/confd.log 2>&1

--- a/node/rc.local
+++ b/node/rc.local
@@ -4,4 +4,4 @@ date > /tmp/boottime.txt
 
 # Run Confd in onetime mode, to ensure that we have a working config in place to allow bird and
 # felix to start.
-./confd -confdir=. -onetime
+./confd -confdir=. -onetime -node ${ETCD_IP}


### PR DESCRIPTION
Adds an environment variable, ETCD_IP, which specifies the IP to send etcd requests for confd.

Could be a proxy or cluster member (ideally the former). confd has a -nodes arg if you want to specify all of the cluster members directly, but we probably prefer to encourage using a local etcd proxy for flexibility.