### PR TITLE
Use names or IDs for calicoctl addtogroup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sh
 requests
 python-etcd
 simplejson
+docker-py


### PR DESCRIPTION
Adds docker-py as a dependency.  We should consider eventually phasing out the sh-based Docker commands we have now.