### PR TITLE
Reinstate missing '/config' directory for confd.

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -4,6 +4,9 @@ FROM phusion/baseimage:0.9.16
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
+# We need this directory for confd's output.
+RUN mkdir -p /config
+
 # Install Calico APT repo.  Note, we delay the apt-get update until 
 # below so that the update is done in the same FS layer as the 
 # install, making it unlikely to be out of sync.

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -4,6 +4,9 @@ FROM phusion/baseimage:0.9.16
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
+# We need this directory for confd's output.
+RUN mkdir -p /config
+
 # Install Calico APT repo.  Note, we delay the apt-get update until 
 # below so that the update is done in the same FS layer as the 
 # install, making it unlikely to be out of sync.


### PR DESCRIPTION
Commit 822ad3c00055332edeee24d4b10c232b50f8b16f removed the
/config directory from the node & master Dockerfiles.

This is required for confd to function.

FIXES metaswitch/calico-docker#18