### PR TITLE
Fix formatting error in node Dockerfile.

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -L https://github.com/kelseyhightower/confd/releases/download/v0.7.1/co
 RUN apt-get update && \
     apt-get install -qy \
         bird \
-        build-essential 
+        build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Missing line continuation was causing 'apt-get' to be parsed as
a new dockerfile command, which fails (without throwing an error).
This caused us to skip the apt-clean step.