### PR TITLE
Update log format to include the source filename.

### DIFF
--- a/node/root_overlay/adapter/powerstrip-calico.py
+++ b/node/root_overlay/adapter/powerstrip-calico.py
@@ -33,9 +33,11 @@ hostname = socket.gethostname()
 
 LISTEN_PORT = 2378
 
+
 def setup_logging(logfile):
     _log.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(name)s %(lineno)d: %(message)s')
+    formatter = logging.Formatter('%(asctime)s [%(levelname)s] %(filename)s.%(name)s %(lineno)d: '
+                                  '%(message)s')
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.INFO)
     handler.setFormatter(formatter)


### PR DESCRIPTION
Used to just log "__main__", which is not descriptive; now we'll
log "filename.__main__".