### PR TITLE
Fix handling of netns with no default-route.

### DIFF
--- a/node/root_overlay/adapter/netns.py
+++ b/node/root_overlay/adapter/netns.py
@@ -121,11 +121,14 @@ def set_up_endpoint(ip, cpid, in_container=False, veth_name=VETH_NAME, proc_alia
     # Set the default route.
     # Is there already a default route?  This occurs if there is already networking set up on
     # the container.  We want Calico to be the default route.
-    curr_default = check_output("ip netns exec %s ip route show | grep default" % cpid,
-                                shell=True)
-    if curr_default:
+    routes = check_output(['ip', 'netns', 'exec', str(cpid), 'ip', 'route'])
+    _log.debug('Netns %d "ip route" output:\n%s', cpid, routes)
+    if 'default' in routes:
         # Delete the default.
-        check_call("ip netns exec %s ip route del default" % (cpid), shell=True)
+        _log.info('Found default route in output, deleting.')
+        _log.debug('"ip route" output:\n%s', routes)
+        check_call("ip netns exec %s ip route del default" % cpid, shell=True)
+
     check_call("ip netns exec %s ip route add default dev %s" % (cpid, veth_name), shell=True)
 
     # Get the MAC address.


### PR DESCRIPTION
netns didn't handle the case with no default route;
the 'ip route | grep default' call returns 1 if there is no match,
and therefore the check_output call fails.

Fix is to parse the returned 'ip route' output in python instead.

Fixes Metaswitch/calico-docker#23