### PR TITLE
Pin requests.py version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pyinstaller
 infi.docopt_completion
 docopt
 sh
-requests
+requests==2.5.1
 python-etcd 0.3.2
 simplejson
 docker-py


### PR DESCRIPTION
Latest (2.5.2 & 2.5.3) requests.py interacts badly with pyinstaller.

See
http://stackoverflow.com/questions/28775276/pyinstaller-error-importerror-no-module-named-requests-packages-chardet-sys