### PR TITLE
Add support for IPv6 networked containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,36 @@ Finally, we provide a command line tool, `calicoctl`, which configures and start
 
 ```
 Usage:
-  calicoctl master --ip=<IP>
-                   [--etcd=<ETCD_AUTHORITY>]
-                   [--master-image=<DOCKER_IMAGE_NAME>]
-  calicoctl node --ip=<IP>
-                 [--etcd=<ETCD_AUTHORITY>]
-                 [--node-image=<DOCKER_IMAGE_NAME>]
-  calicoctl status [--etcd=<ETCD_AUTHORITY>]
-  calicoctl reset [--etcd=<ETCD_AUTHORITY>]
-  calicoctl version [--etcd=<ETCD_AUTHORITY>]
-  calicoctl addgroup <GROUP>  [--etcd=<ETCD_AUTHORITY>]
-  calicoctl addtogroup <CONTAINER_ID> <GROUP>
-                       [--etcd=<ETCD_AUTHORITY>]
-  calicoctl diags
+  calicoctl master --ip=<IP> [--master-image=<DOCKER_IMAGE_NAME>]
+  calicoctl master stop [--force]
+  calicoctl node --ip=<IP> [--node-image=<DOCKER_IMAGE_NAME>] [--ip6=<IP6>]
+  calicoctl node stop [--force]
   calicoctl status
+  calicoctl shownodes [--detailed]
+  calicoctl group show [--detailed]
+  calicoctl group add <GROUP>
+  calicoctl group remove <GROUP>
+  calicoctl group addmember <GROUP> <CONTAINER>
+  calicoctl group removemember <GROUP> <CONTAINER>
+  calicoctl ipv4 pool add <CIDR>
+  calicoctl ipv4 pool del <CIDR>
+  calicoctl ipv4 pool show
+  calicoctl ipv6 pool add <CIDR>
+  calicoctl ipv6 pool del <CIDR>
+  calicoctl ipv6 pool show
+  calicoctl container add <CONTAINER> <IP>
+  calicoctl container remove <CONTAINER> [--force]
   calicoctl reset
+  calicoctl diags
+
 Options:
  --ip=<IP>                The local management address to use.
- --etcd=<ETCD_AUTHORITY>  The location of the etcd service as
-                          host:port [default: 127.0.0.1:4001]
+ --ip6=<IP6>              The local IPv6 management address to use.
  --master-image=<DOCKER_IMAGE_NAME>  Docker image to use for
                           Calico's master container
-                          [default: calico/master:v0.0.6]
+                          [default: calico/master:latest]
  --node-image=<DOCKER_IMAGE_NAME>    Docker image to use for
                           Calico's per-node container
-                          [default: calico/node:v0.0.6]
+                          [default: calico/node:latest]
 
 ```

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -235,7 +235,7 @@ def node(ip, node_image, ip6=""):
     # Set up etcd
     client = DatastoreClient()
 
-    # Enable IP forwarding.
+    # Enable IP forwarding since all compute hosts are vRouters.
     sysctl("-w", "net.ipv4.ip_forward=1")
     sysctl("-w", "net.ipv6.conf.all.forwarding=1")
 
@@ -244,6 +244,8 @@ def node(ip, node_image, ip6=""):
         print "No master can be found. Exiting"
         return
 
+    # Creating the master also should set up the IP pool information.  Since
+    # bird and bird6 will not be able to start without these, check them now.
     ipv4_pools = client.get_ip_pools("v4")
     if not ipv4_pools:
         print "No IPv4 range defined.  Exiting."

--- a/datastore.py
+++ b/datastore.py
@@ -51,7 +51,7 @@ class DatastoreClient(object):
         (host, port) = etcd_authority.split(":", 1)
         self.etcd_client = etcd.Client(host=host, port=int(port))
 
-    def create_host(self, bird_ip):
+    def create_host(self, bird_ip, bird6_ip):
         """
         Create a new Calico host.
 
@@ -61,6 +61,7 @@ class DatastoreClient(object):
         host_path = HOST_PATH % {"hostname": hostname}
         # Set up the host
         self.etcd_client.write(host_path + "bird_ip", bird_ip)
+        self.etcd_client.write(host_path + "bird6_ip", bird6_ip)
         workload_dir = host_path + "workload"
         try:
             self.etcd_client.read(workload_dir)

--- a/master/root_overlay/plugin.py
+++ b/master/root_overlay/plugin.py
@@ -185,6 +185,7 @@ def do_ep_api():
             rsp = {"rc": "SUCCESS",
                    "message": "Hooray",
                    "type": fields['type'],
+                   "interface_prefix": "tap",
                    "endpoint_count": str(len(eps_by_host.get(host, set())))}
             rsp_json = json.dumps(rsp)
             log_api.info("Sending RESYNCSTATE response to %s\n%s", host, rsp_json)
@@ -242,9 +243,11 @@ def send_all_eps(create_sockets, host, resync_id):
     # Send all of the ENDPOINTCREATED messages.
     for ep in eps_by_host.get(host, {}):
         log.info("Sending ENDPOINTCREATED message for endpoint %s", ep)
+        if_name = "tap" + ep[:11]
         msg = {"type": "ENDPOINTCREATED",
                "mac": eps_by_host[host][ep]["mac"],
                "endpoint_id": ep,
+               "interface_name":  if_name,
                "resync_id": resync_id,
                "issued": int(time.time() * 1000),
                "state": "enabled", # TODO - Map through enabled properly

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -40,7 +40,8 @@ RUN curl -L https://github.com/kelseyhightower/confd/releases/download/v0.7.1/co
 RUN apt-get update && \
     apt-get install -qy \
         bird \
-        build-essential 
+        bird6 \
+        build-essential && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/node/root_overlay/adapter/calico_etcd.py
+++ b/node/root_overlay/adapter/calico_etcd.py
@@ -23,6 +23,7 @@ import sys
 import os
 import logging
 import logging.handlers
+from netaddr import IPAddress
 
 _log = logging.getLogger(__name__)
 
@@ -90,3 +91,15 @@ class CalicoEtcdClient(object):
             _log.exception("Hit Exception %s writing to etcd.", e)
             pass
 
+    def get_default_next_hops(self, hostname):
+        """
+        Get the next hop IP addresses for default routes on the given host.
+
+        :param hostname: The hostname for which to get default route next hops.
+        :return: Dict of {ip_version: IPAddress}
+        """
+
+        host_path = HOST_PATH % {"hostname": hostname}
+        ipv4 = self.client.read(host_path + "bird_ip").value
+        ipv6 = self.client.read(host_path + "bird6_ip").value
+        return {4: IPAddress(ipv4), 6: IPAddress(ipv6)}

--- a/node/root_overlay/adapter/netns.py
+++ b/node/root_overlay/adapter/netns.py
@@ -30,13 +30,16 @@ VETH_NAME = "eth0"
 """The name to give to the veth in the target container's namespace"""
 
 ROOT_NETNS = "1"
-"""The pid of the root namespace.  On almost all systems, the init system is pid 1"""
+"""The pid of the root namespace.  On almost all systems, the init system is
+pid 1
+"""
 
 PREFIX_LEN = {4: 32, 6: 128}
 """The IP address prefix length to assign, by IP version."""
 
 PROC_ALIAS = "proc_host"
-"""The alias for /proc.  This is useful when the filesystem is containerized."""
+"""The alias for /proc.  This is useful when the filesystem is containerized.
+"""
 
 
 def setup_logging(logfile):
@@ -72,13 +75,17 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
     """
     Set up an endpoint (veth) in the network namespace idenfitied by the PID.
 
-    :param ip: The IP address to assign to the endpoint (veth) as Netaddr IPAddress.
+    :param ip: The IP address to assign to the endpoint (veth) as Netaddr
+    IPAddress.
     :param cpid: The PID of a process currently running in the namespace.
-    :param next_hop_ips: Dict of {version: IPAddress} for the next hops of the default routes.
-    :param in_container: When True, we assume this program is itself running in a container
-    namespace, as opposed to the root namespace.  If so, this method also moves the other end of
-    the veth into the root namespace.
-    :param veth_name: The name of the interface inside the container namespace, e.g. eth0
+    :param next_hop_ips: Dict of {version: IPAddress} for the next hops of the
+    default routes.
+    :param in_container: When True, we assume this program is itself running in
+    a container
+    namespace, as opposed to the root namespace.  If so, this method also moves
+    the other end of the veth into the root namespace.
+    :param veth_name: The name of the interface inside the container namespace,
+    e.g. eth0
     :param proc_alias: The head of the /proc filesystem on the host.
     :return: An Endpoint describing the veth just created.
     """
@@ -119,15 +126,17 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
                shell=True)
     check_call("ip netns exec %s ip link set %s up" % (cpid, veth_name), shell=True)
 
-    # If in container, the iface end of the veth pair will be in the container namespace.  We need
-    # to move it to the root namespace so it will participate in routing.
+    # If in container, the iface end of the veth pair will be in the container
+    # namespace.  We need to move it to the root namespace so it will
+    # participate in routing.
     if in_container:
         # Move the other end of the veth pair into the root namespace
         check_call("ip link set %s netns %s" % (iface, ROOT_NETNS), shell=True)
         check_call("ip netns exec %s ip link set %s up" % (ROOT_NETNS, iface), shell=True)
 
     # Add an IP address.
-    check_call("ip netns exec %(cpid)s ip -%(version)s addr add %(addr)s/%(len)s dev %(device)s" %
+    check_call("ip netns exec %(cpid)s ip -%(version)s addr add "
+               "%(addr)s/%(len)s dev %(device)s" %
                {"cpid": cpid,
                 "version": ip.version,
                 "len": PREFIX_LEN[ip.version],

--- a/node/root_overlay/adapter/netns.py
+++ b/node/root_overlay/adapter/netns.py
@@ -158,7 +158,7 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
 
     # Return an Endpoint
     return Endpoint(id=ep_id,
-                    addrs=[{"addr": str(ip), "gw": str(next_hop)}],
+                    addrs=[{"addr": str(ip), "gateway": str(next_hop)}],
                     state="enabled",
                     mac=mac)
 

--- a/node/root_overlay/adapter/powerstrip-calico.py
+++ b/node/root_overlay/adapter/powerstrip-calico.py
@@ -23,6 +23,7 @@ from docker import Client
 import netns
 import calico_etcd
 import socket
+from netaddr import IPAddress
 
 _log = logging.getLogger(__name__)
 
@@ -59,7 +60,8 @@ class AdapterResource(resource.Resource):
         resource.Resource.__init__(self)
 
         # Init a Docker client, to save having to do so every time a request comes in.
-        self.docker = Client(base_url='unix://var/run/docker.sock')
+        self.docker = Client(base_url='unix://var/run/docker.sock',
+                             version="1.16")
 
         # Init an etcd client.
         self.etcd = calico_etcd.CalicoEtcdClient()
@@ -126,7 +128,8 @@ class AdapterResource(resource.Resource):
             # Attempt to parse out environment variables
             env_list = cont["Config"]["Env"]
             env_dict = env_to_dictionary(env_list)
-            ip = env_dict[ENV_IP]
+            ip_str = env_dict[ENV_IP]
+            ip = IPAddress(ip_str)
 
             # TODO: process groups
             group = env_dict.get(ENV_GROUP, None)

--- a/node/root_overlay/adapter/powerstrip-calico.py
+++ b/node/root_overlay/adapter/powerstrip-calico.py
@@ -23,7 +23,7 @@ from docker import Client
 import netns
 import calico_etcd
 import socket
-from netaddr import IPAddress
+from netaddr import IPAddress, AddrFormatError
 
 _log = logging.getLogger(__name__)
 
@@ -129,19 +129,24 @@ class AdapterResource(resource.Resource):
             env_list = cont["Config"]["Env"]
             env_dict = env_to_dictionary(env_list)
             ip_str = env_dict[ENV_IP]
-            ip = IPAddress(ip_str)
-
             # TODO: process groups
             group = env_dict.get(ENV_GROUP, None)
-
-            endpoint = netns.set_up_endpoint(ip=ip, cpid=pid)
-            self.etcd.create_container(hostname=hostname,
-                                       container_id=cid,
-                                       endpoint=endpoint)
-            _log.info("Finished network for container %s, IP=%s", cid, ip)
-
         except KeyError as e:
             _log.warning("Key error %s, request: %s", e, client_request)
+            return
+
+        try:
+            ip = IPAddress(ip_str)
+        except AddrFormatError:
+            _log.warning("IP address %s could not be parsed" % ip_str)
+            return
+
+        next_hop_ips = self.etcd.get_default_next_hops(hostname)
+        endpoint = netns.set_up_endpoint(ip=ip, cpid=pid, next_hop_ips=next_hop_ips)
+        self.etcd.create_container(hostname=hostname,
+                                   container_id=cid,
+                                   endpoint=endpoint)
+        _log.info("Finished network for container %s, IP=%s", cid, ip)
 
         return
 

--- a/node/root_overlay/conf.d/bird6.toml
+++ b/node/root_overlay/conf.d/bird6.toml
@@ -1,0 +1,8 @@
+[template]
+src = "bird6.cfg.template"
+dest = "/config/bird6.cfg"
+keys = [
+    "/calico/host",
+    "/calico/ipam/v6/pool"
+]
+reload_cmd = "pkill -HUP bird6 || true"

--- a/node/root_overlay/etc/rc.local
+++ b/node/root_overlay/etc/rc.local
@@ -2,6 +2,6 @@
 # Record current boot time. Helps with debugging.
 date > /tmp/boottime.txt
 
-# Run Confd in onetime mode, to ensure that we have a working config in place to allow bird and
+# Run Confd in onetime mode, to ensure that we have a working config in place to allow bird(s) and
 # felix to start.
 ./confd -confdir=. -onetime -node ${ETCD_AUTHORITY}

--- a/node/root_overlay/etc/service/bird6/run
+++ b/node/root_overlay/etc/service/bird6/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec bird6 -s bird6.ctl -d -c /config/bird6.cfg >>/var/log/calico/bird6.log 2>&1

--- a/node/root_overlay/templates/bird6.cfg.template
+++ b/node/root_overlay/templates/bird6.cfg.template
@@ -1,0 +1,51 @@
+router id {{getenv "IP"}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
+log "/var/log/calico/bird6.log" all;
+
+filter calico_pools {
+{{range gets "/calico/ipam/v6/pool/*"}}
+    if ( net ~ {{.Value}} ) then {
+        accept;
+    }
+{{end}}
+    reject;
+}
+
+# Configure synchronization between routing tables and kernel.
+protocol kernel {
+  learn;          # Learn all alien routes from the kernel
+  persist;        # Don't remove routes on bird shutdown
+  scan time 2;    # Scan kernel routing table every 2 seconds
+  import all;
+  device routes;
+  export all;     # Default is export none
+}
+
+# Watch interface up/down events.
+protocol device {
+  scan time 2;    # Scan interfaces every 2 seconds
+}
+
+protocol direct {
+   debug all;
+   interface "eth*", "em*", "ens*";
+}
+
+{{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.{{else}}# Peer with all neighbours.
+{{range gets "/calico/host/*/bird6_ip"}}
+# For peer {{.Key}} {{if eq .Value (getenv "IP6") }}
+# Skipping ourselves ({{getenv "IP6"}}) {{else}}
+protocol bgp {
+  debug all;
+  description "Connection to BGP peer";
+  local as 64511;
+  neighbor {{.Value}} as 64511;
+  multihop;
+  gateway recursive; # This should be the default, but just in case.
+  import filter calico_pools;
+  export filter calico_pools;
+  next hop self;    # Disable next hop processing and always advertise our
+                    # local address as nexthop
+  source address {{getenv "IP6"}};  # The local address we use for the TCP connection
+}
+{{end}}{{end}}{{end}}
+


### PR DESCRIPTION
High level changes:
 - add commands for IPv6 address pools
 - add bird6 to calico-node with Confd configuration
 - move to latest calico-felix (including zeroMQ API update for interface names) for proxy NDP config
 - program containers with local gateway, rather than default via device directly
 - version checking of IP address to program netns correctly 