### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Circle CI](https://circleci.com/gh/Metaswitch/calico-docker/tree/master.svg?style=svg)](https://circleci.com/gh/Metaswitch/calico-docker/tree/master)
 # Calico on Docker
-Calico can provide networking in a Docker environment. Each container gets its own IP, there is no encapsulation and it can support massive scale. For more details see http://www.projectcalico.org/technical/
+Calico can provide networking in a Docker environment. Each container gets its own IP, there is no encapsulation and it can support massive scale. For more information on Project Calico see http://www.projectcalico.org/learn/
 
 Development is very active at the moment so please Star this project and check back often.
 


### PR DESCRIPTION
Correct the website link at the top of the page (www.projectcalico.org/technical no longer exists).

Addresses issue https://github.com/Metaswitch/calico-docker/issues/44.