### PR TITLE
Add calicoctl commands for BGP Peers (and configurable AS)

### DIFF
--- a/calicoctl.py
+++ b/calicoctl.py
@@ -732,6 +732,7 @@ def ip_pool_add(cidr_pool, version):
     :param version: v4 or v6
     :return: None
     """
+    assert version in ("v4", "v6")
     try:
         pool = IPNetwork(cidr_pool)
     except AddrFormatError:
@@ -752,6 +753,7 @@ def ip_pool_remove(cidr_pool, version):
     :param version: v4 or v6
     :return: None
     """
+    assert version in ("v4", "v6")
     try:
         pool = IPNetwork(cidr_pool)
     except AddrFormatError:

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -10,20 +10,16 @@ Usage:
   calicoctl status
   calicoctl shownodes [--detailed]
   calicoctl profile show [--detailed]
-  calicoctl profile add <PROFILE>
-  calicoctl profile remove <PROFILE>
+  calicoctl profile (add|remove) <PROFILE>
   calicoctl profile <PROFILE> tag show
-  calicoctl profile <PROFILE> tag add <TAG>
-  calicoctl profile <PROFILE> tag remove <TAG>
+  calicoctl profile <PROFILE> tag (add|remove) <TAG>
   calicoctl profile <PROFILE> rule show
   calicoctl profile <PROFILE> rule json
   calicoctl profile <PROFILE> rule update
   calicoctl profile <PROFILE> member add <CONTAINER>
-  calicoctl (ipv4|ipv6) pool add <CIDR>
-  calicoctl (ipv4|ipv6) pool del <CIDR>
+  calicoctl (ipv4|ipv6) pool (add|del) <CIDR>
   calicoctl (ipv4|ipv6) pool show
-  calicoctl (ipv4|ipv6) bgppeer add <IP>
-  calicoctl (ipv4|ipv6) bgppeer del <IP>
+  calicoctl (ipv4|ipv6) bgppeer (add|del) <IP>
   calicoctl (ipv4|ipv6) bgppeer show
   calicoctl container add <CONTAINER> <IP>
   calicoctl container remove <CONTAINER> [--force]

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -211,7 +211,7 @@ def container_remove(container_name):
         endpoint_id = client.get_ep_id_from_cont(hostname, container_id)
     except KeyError:
         print "Container %s doesn't contain any endpoints" % container_name
-        return
+        sys.exit(1)
 
     # Remove any IP address assignments that this endpoint has
     endpoint = client.get_endpoint(hostname, container_id, endpoint_id)
@@ -494,7 +494,7 @@ def profile_add_container(container_name, profile_name):
 
     if not client.profile_exists(profile_name):
         print "Profile with name %s was not found." % profile_name
-        return
+        sys.exit(1)
 
     client.add_workload_to_profile(hostname, profile_name, container_id)
     print "Added %s to %s" % (container_name, profile_name)
@@ -737,11 +737,11 @@ def ip_pool_add(cidr_pool, version):
         pool = IPNetwork(cidr_pool)
     except AddrFormatError:
         print "%s is not a valid IP prefix." % cidr_pool
-        return
+        sys.exit(1)
     if "v%d" % pool.version != version:
         print "%s is an IPv%d prefix, this command is for IP%s." % \
               (cidr_pool, pool.version, version)
-        return
+        sys.exit(1)
     client.add_ip_pool(version, pool)
 
 
@@ -758,11 +758,11 @@ def ip_pool_remove(cidr_pool, version):
         pool = IPNetwork(cidr_pool)
     except AddrFormatError:
         print "%s is not a valid IP prefix." % cidr_pool
-        return
+        sys.exit(1)
     if "v%d" % pool.version != version:
         print "%s is an IPv%d prefix, this command is for IP%s." % \
               (cidr_pool, pool.version, version)
-        return
+        sys.exit(1)
     try:
         client.remove_ip_pool(version, pool)
     except KeyError:
@@ -817,11 +817,11 @@ def bgppeer_add(ip, version):
         address = IPAddress(ip)
     except AddrFormatError:
         print "%s is not a valid IP address." % address
-        return
+        sys.exit(1)
     if "v%d" % address.version != version:
         print "%s is an IPv%d prefix, this command is for IP%s." % \
               (ip, address.version, version)
-        return
+        sys.exit(1)
     client.add_bgp_peer(version, address)
 
 
@@ -837,11 +837,11 @@ def bgppeer_remove(ip, version):
         address = IPAddress(ip)
     except AddrFormatError:
         print "%s is not a valid IP address." % address
-        return
+        sys.exit(1)
     if "v%d" % address.version != version:
         print "%s is an IPv%d prefix, this command is for IP%s." % \
               (ip, address.version, version)
-        return
+        sys.exit(1)
     try:
         client.remove_bgp_peer(version, address)
     except KeyError:

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -19,8 +19,8 @@ Usage:
   calicoctl profile <PROFILE> member add <CONTAINER>
   calicoctl (ipv4|ipv6) pool (add|remove) <CIDR>
   calicoctl (ipv4|ipv6) pool show
-  calicoctl (ipv4|ipv6) bgppeer (add|remove) <IP>
-  calicoctl (ipv4|ipv6) bgppeer show
+  calicoctl (ipv4|ipv6) bgppeer rr (add|remove) <IP>
+  calicoctl (ipv4|ipv6) bgppeer rr show
   calicoctl container add <CONTAINER> <IP>
   calicoctl container remove <CONTAINER> [--force]
   calicoctl reset
@@ -851,7 +851,7 @@ def bgppeer_show(version):
     """
     Print a list BGP Peers
     """
-    peers = client.get_bgp_peer(version)
+    peers = client.get_bgp_peers(version)
     if peers:
         x = PrettyTable(["BGP Peer"], sortby="BGP Peer")
         for peer in peers:
@@ -923,7 +923,7 @@ if __name__ == '__main__':
                     ip_pool_remove(arguments["<CIDR>"], version)
                 elif arguments["show"]:
                     ip_pool_show(version)
-            elif arguments["bgppeer"]:
+            elif arguments["bgppeer"] and arguments["rr"]:
                 if arguments["add"]:
                     bgppeer_add(arguments["<IP>"], version)
                 elif arguments["remove"]:

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -503,7 +503,7 @@ def profile_add_container(container_name, profile_name):
 def profile_remove(profile_name):
     # TODO - Don't allow removing a profile that has endpoints in it.
     try:
-        client.delete_profile(profile_name)
+        client.remove_profile(profile_name)
     except KeyError:
         print "Couldn't find profile with name %s" % profile_name
     else:
@@ -762,7 +762,7 @@ def ip_pool_remove(cidr_pool, version):
               (cidr_pool, pool.version, version)
         return
     try:
-        client.del_ip_pool(version, pool)
+        client.remove_ip_pool(version, pool)
     except KeyError:
         print "%s is not a configured pool." % cidr_pool
 
@@ -841,7 +841,7 @@ def bgppeer_remove(ip, version):
               (ip, address.version, version)
         return
     try:
-        client.delete_bgp_peer(version, address)
+        client.remove_bgp_peer(version, address)
     except KeyError:
         print "%s is not a configured peer." % address
 

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -17,9 +17,9 @@ Usage:
   calicoctl profile <PROFILE> rule json
   calicoctl profile <PROFILE> rule update
   calicoctl profile <PROFILE> member add <CONTAINER>
-  calicoctl (ipv4|ipv6) pool (add|del) <CIDR>
+  calicoctl (ipv4|ipv6) pool (add|remove) <CIDR>
   calicoctl (ipv4|ipv6) pool show
-  calicoctl (ipv4|ipv6) bgppeer (add|del) <IP>
+  calicoctl (ipv4|ipv6) bgppeer (add|remove) <IP>
   calicoctl (ipv4|ipv6) bgppeer show
   calicoctl container add <CONTAINER> <IP>
   calicoctl container remove <CONTAINER> [--force]
@@ -823,7 +823,7 @@ def bgppeer_add(ip, version):
     client.add_bgp_peer(version, address)
 
 
-def bgppeer_delete(ip, version):
+def bgppeer_remove(ip, version):
     """
     Add the the given BGP Peer.
 
@@ -917,15 +917,15 @@ if __name__ == '__main__':
             if arguments["pool"]:
                 if arguments["add"]:
                     ip_pool_add(arguments["<CIDR>"], version)
-                elif arguments["del"]:
+                elif arguments["remove"]:
                     ip_pool_remove(arguments["<CIDR>"], version)
                 elif arguments["show"]:
                     ip_pool_show(version)
             elif arguments["bgppeer"]:
                 if arguments["add"]:
                     bgppeer_add(arguments["<IP>"], version)
-                elif arguments["del"]:
-                    bgppeer_delete(arguments["<IP>"], version)
+                elif arguments["remove"]:
+                    bgppeer_remove(arguments["<IP>"], version)
                 elif arguments["show"]:
                     bgppeer_show(version)
         if arguments["container"]:

--- a/node/adapter/datastore.py
+++ b/node/adapter/datastore.py
@@ -281,7 +281,7 @@ class DatastoreClient(object):
         pool_path = IP_POOL_PATH % {"version": version}
         self.etcd_client.write(pool_path, str(pool), append=True)
 
-    def del_ip_pool(self, version, pool):
+    def remove_ip_pool(self, version, pool):
         """
         Delete the given CIDR range from the list of pools.  If the pool does
         not exist, raise a KeyError.
@@ -354,7 +354,7 @@ class DatastoreClient(object):
 
         self.etcd_client.write(bgp_peer_path, str(ip), append=True)
 
-    def delete_bgp_peer(self, version, ip):
+    def remove_bgp_peer(self, version, ip):
         """
         Delete a BGP Peer
 
@@ -412,7 +412,7 @@ class DatastoreClient(object):
                       outbound_rules=[default_allow])
         self.etcd_client.write(profile_path + "rules", rules.to_json())
 
-    def delete_profile(self, name):
+    def remove_profile(self, name):
         """
         Delete a policy profile with a given name.
 

--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -38,8 +38,8 @@ protocol direct {
 protocol bgp {
   debug all;
   description "Connection to BGP peer";
-  local as 64511;
-  neighbor {{.Value}} as 64511;
+  local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import filter calico_pools;
@@ -57,8 +57,8 @@ protocol bgp {
 protocol bgp {
   debug all;
   description "Connection to BGP peer";
-  local as 64511;
-  neighbor {{.Value}} as 64511;
+  local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import filter calico_pools;

--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -31,9 +31,9 @@ protocol direct {
    interface "eth*", "em*", "ens*";
 }
 
-{{if ls "/calico/config/bgp_peers"}}
+{{if ls "/calico/config/bgp_peer_v4"}}
 # Peer with configured neighbors
-{{range gets "/calico/config/bgp_peers/*"}}
+{{range gets "/calico/config/bgp_peer_v4/*"}}
 # For peer {{.Value}}
 protocol bgp {
   debug all;

--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -31,9 +31,9 @@ protocol direct {
    interface "eth*", "em*", "ens*";
 }
 
-{{if ls "/calico/config/bgp_peer_v4"}}
+{{if ls "/calico/config/bgp_peer_rr_v4"}}
 # Peer with configured neighbors
-{{range gets "/calico/config/bgp_peer_v4/*"}}
+{{range gets "/calico/config/bgp_peer_rr_v4/*"}}
 # For peer {{.Value}}
 protocol bgp {
   debug all;

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -40,8 +40,8 @@ protocol direct {
 protocol bgp {
   debug all;
   description "Connection to BGP peer";
-  local as 64511;
-  neighbor {{.Value}} as 64511;
+  local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import filter calico_pools;
@@ -59,8 +59,8 @@ protocol bgp {
 protocol bgp {
   debug all;
   description "Connection to BGP peer";
-  local as 64511;
-  neighbor {{.Value}} as 64511;
+  local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import filter calico_pools;

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -33,9 +33,9 @@ protocol direct {
 
 {{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.
 {{else}}
-{{if ls "/calico/config/bgp_peers_ipv6"}}
+{{if ls "/calico/config/bgp_peer_v6"}}
 # Peer with configured neighbors
-{{range gets "/calico/config/bgp_peers_ipv6/*"}}
+{{range gets "/calico/config/bgp_peer_v6/*"}}
 # For peer {{.Value}}
 protocol bgp {
   debug all;

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -33,9 +33,9 @@ protocol direct {
 
 {{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.
 {{else}}
-{{if ls "/calico/config/bgp_peer_v6"}}
+{{if ls "/calico/config/bgp_peer_rr_v6"}}
 # Peer with configured neighbors
-{{range gets "/calico/config/bgp_peer_v6/*"}}
+{{range gets "/calico/config/bgp_peer_rr_v6/*"}}
 # For peer {{.Value}}
 protocol bgp {
   debug all;

--- a/tests/unit/datastore_test.py
+++ b/tests/unit/datastore_test.py
@@ -463,23 +463,23 @@ class TestDatastoreClient(unittest.TestCase):
 
     def test_del_ip_pool_exists(self):
         """
-        Test del_ip_pool() when the pool does exist.
+        Test remove_ip_pool() when the pool does exist.
         :return: None
         """
         self.etcd_client.read.side_effect = mock_read_2_pools
         pool = IPNetwork("192.168.3.1/24")
-        self.datastore.del_ip_pool("v4", pool)
+        self.datastore.remove_ip_pool("v4", pool)
         # 192.168.3.0/24 has a key .../v4/pool/0 in the ordered list.
         self.etcd_client.delete.assert_called_once_with(IPV4_POOLS_PATH + "0")
 
     def test_del_ip_pool_doesnt_exist(self):
         """
-        Test del_ip_pool() when the pool does not exist.
+        Test remove_ip_pool() when the pool does not exist.
         :return: None
         """
         self.etcd_client.read.side_effect = mock_read_2_pools
         pool = IPNetwork("192.168.100.1/24")
-        assert_raises(KeyError, self.datastore.del_ip_pool, "v4", pool)
+        assert_raises(KeyError, self.datastore.remove_ip_pool, "v4", pool)
         assert_false(self.etcd_client.delete.called)
 
     def test_profile_exists_true(self):
@@ -522,7 +522,7 @@ class TestDatastoreClient(unittest.TestCase):
         """
         Test deleting a policy profile.
         """
-        self.datastore.delete_profile("TEST")
+        self.datastore.remove_profile("TEST")
         self.etcd_client.delete.assert_called_once_with(TEST_PROFILE_PATH,
                                                         recursive=True,
                                                         dir=True)
@@ -848,7 +848,7 @@ class TestDatastoreClient(unittest.TestCase):
         """
         self.etcd_client.read.side_effect = mock_read_2_peers
         peer = IPAddress("192.168.3.1")
-        self.datastore.delete_bgp_peer("v4", peer)
+        self.datastore.remove_bgp_peer("v4", peer)
         # 192.168.3.0 has a key ...v4/0 in the ordered list.
         self.etcd_client.delete.assert_called_once_with(BGP_PEERS_PATH + "0")
 
@@ -859,7 +859,7 @@ class TestDatastoreClient(unittest.TestCase):
         """
         self.etcd_client.read.side_effect = mock_read_2_peers
         peer = IPAddress("192.168.100.1")
-        assert_raises(KeyError, self.datastore.delete_bgp_peer, "v4", peer)
+        assert_raises(KeyError, self.datastore.remove_bgp_peer, "v4", peer)
         assert_false(self.etcd_client.delete.called)
 
 


### PR DESCRIPTION
Configure AS using 
- etcdctl set /calico/config/bgp_as 64512

