### PR TITLE
Fix import policy in bird to allow all routes.

### DIFF
--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -42,8 +42,10 @@ protocol bgp {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
-  import filter calico_pools;
-  export filter calico_pools;
+  # Import all routes, since we don't know what the upstream topology is and
+  # therefore have to trust the ToR/RR.
+  import all;
+  export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP"}};  # The local address we use for the TCP connection

--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -63,8 +63,10 @@ protocol bgp {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
+  # Import all routes, since we don't know what the upstream topology is and
+  # therefore have to trust the ToR/RR.
   import all;
-  export filter calico_pools;
+  export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP"}};  # The local address we use for the TCP connection

--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -63,7 +63,7 @@ protocol bgp {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
-  import filter calico_pools;
+  import all;
   export filter calico_pools;
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -65,8 +65,10 @@ protocol bgp {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
+  # Import all routes, since we don't know what the upstream topology is and
+  # therefore have to trust the ToR/RR.
   import all;
-  export filter calico_pools;
+  export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP6"}};  # The local address we use for the TCP connection

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -65,7 +65,7 @@ protocol bgp {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
-  import filter calico_pools;
+  import all;
   export filter calico_pools;
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -44,8 +44,10 @@ protocol bgp {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
-  import filter calico_pools;
-  export filter calico_pools;
+  # Import all routes, since we don't know what the upstream topology is and
+  # therefore have to trust the ToR/RR.
+  import all;
+  export filter calico_pools;  # Only want to export routes for workloads.
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP6"}};  # The local address we use for the TCP connection


### PR DESCRIPTION
Previously we applied the same filter to import and export policy,
so only prefixes specified in etcd would be imported.

Relax this restriction, under the assumption that the RR/ToR
will be configured to only export sensible routes to us.