### PR TITLE
Upgrade Bird to 1.4.5, and enable BGP add-path.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@ CMD ["/sbin/my_init"]
 #    echo "Pin: origin binaries.projectcalico.org" >> /etc/apt/preferences && \
 #    echo "Pin-Priority: 1001" >> /etc/apt/preferences
 
-RUN apt-get update && \
+# Ensure UTF-8, required for add-apt-repository call.
+RUN locale-gen en_US.UTF-8
+ENV LANG       en_US.UTF-8
+ENV LC_ALL     en_US.UTF-8
+
+RUN add-apt-repository -y ppa:cz.nic-labs/bird && \
+    apt-get update && \
     apt-get install -qy \
 #        calico-felix \
         bird \

--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -49,6 +49,7 @@ protocol bgp {
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP"}};  # The local address we use for the TCP connection
+  add paths on;
 }
 {{end}}
 {{else}}
@@ -70,6 +71,7 @@ protocol bgp {
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP"}};  # The local address we use for the TCP connection
+  add paths on;
 }
 {{end}}{{end}}
 {{end}}

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -51,6 +51,7 @@ protocol bgp {
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP6"}};  # The local address we use for the TCP connection
+  add paths on;
 }
 {{end}}
 {{else}}
@@ -72,6 +73,7 @@ protocol bgp {
   next hop self;    # Disable next hop processing and always advertise our
                     # local address as nexthop
   source address {{getenv "IP6"}};  # The local address we use for the TCP connection
+  add paths on;
 }
 {{end}}{{end}}{{end}}
 {{end}}


### PR DESCRIPTION
Add-path is required for Bird to advertise ECMP IPs. If it's not
enabled, Bird will refuse to advertise its route to the ECMP
IP if there's another copy of that route already advertised by
another node.