### PR TITLE
Refactor bird config files to use bgp template.

### DIFF
--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -31,15 +31,11 @@ protocol direct {
    interface "eth*", "em*", "ens*";
 }
 
-{{if ls "/calico/config/bgp_peer_rr_v4"}}
-# Peer with configured neighbors
-{{range gets "/calico/config/bgp_peer_rr_v4/*"}}
-# For peer {{.Value}}
-protocol bgp {
+# Template for all BGP clients
+template bgp bgp_template {
   debug all;
   description "Connection to BGP peer";
   local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
-  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   # Import all routes, since we don't know what the upstream topology is and
@@ -51,27 +47,23 @@ protocol bgp {
   source address {{getenv "IP"}};  # The local address we use for the TCP connection
   add paths on;
 }
+
+{{if ls "/calico/config/bgp_peer_rr_v4"}}
+# Peer with configured neighbors
+{{range gets "/calico/config/bgp_peer_rr_v4/*"}}
+# For peer {{.Value}}
+protocol bgp from bgp_template {
+  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+
+}
 {{end}}
 {{else}}
 # Peer with all neighbours
 {{range gets "/calico/host/*/bird_ip"}}
 # For peer {{.Key}} {{if eq .Value (getenv "IP") }}
 # Skipping ourselves ({{getenv "IP"}}) {{else}}
-protocol bgp {
-  debug all;
-  description "Connection to BGP peer";
-  local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+protocol bgp from bgp_template {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
-  multihop;
-  gateway recursive; # This should be the default, but just in case.
-  # Import all routes, since we don't know what the upstream topology is and
-  # therefore have to trust the ToR/RR.
-  import all;
-  export filter calico_pools;  # Only want to export routes for workloads.
-  next hop self;    # Disable next hop processing and always advertise our
-                    # local address as nexthop
-  source address {{getenv "IP"}};  # The local address we use for the TCP connection
-  add paths on;
 }
 {{end}}{{end}}
 {{end}}

--- a/node/templates/bird6.cfg.template
+++ b/node/templates/bird6.cfg.template
@@ -31,17 +31,11 @@ protocol direct {
    interface "eth*", "em*", "ens*";
 }
 
-{{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.
-{{else}}
-{{if ls "/calico/config/bgp_peer_rr_v6"}}
-# Peer with configured neighbors
-{{range gets "/calico/config/bgp_peer_rr_v6/*"}}
-# For peer {{.Value}}
-protocol bgp {
+# Template for all BGP clients
+template bgp bgp_template {
   debug all;
   description "Connection to BGP peer";
   local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
-  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
   multihop;
   gateway recursive; # This should be the default, but just in case.
   # Import all routes, since we don't know what the upstream topology is and
@@ -53,27 +47,24 @@ protocol bgp {
   source address {{getenv "IP6"}};  # The local address we use for the TCP connection
   add paths on;
 }
+
+{{if eq "" (getenv "IP6")}}# IPv6 disabled on this node.
+{{else}}
+{{if ls "/calico/config/bgp_peer_rr_v6"}}
+# Peer with configured neighbors
+{{range gets "/calico/config/bgp_peer_rr_v6/*"}}
+# For peer {{.Value}}
+protocol bgp from bgp_template {
+  neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+}
 {{end}}
 {{else}}
 # Peer with all neighbours.
 {{range gets "/calico/host/*/bird6_ip"}}
 # For peer {{.Key}} {{if eq .Value (getenv "IP6") }}
 # Skipping ourselves ({{getenv "IP6"}}) {{else if ne "" .Value}}
-protocol bgp {
-  debug all;
-  description "Connection to BGP peer";
-  local as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
+protocol bgp from bgp_template {
   neighbor {{.Value}} as {{if exists "/calico/config/bgp_as"}}{{getv "/calico/config/bgp_as"}}{{else}}64511{{end}};
-  multihop;
-  gateway recursive; # This should be the default, but just in case.
-  # Import all routes, since we don't know what the upstream topology is and
-  # therefore have to trust the ToR/RR.
-  import all;
-  export filter calico_pools;  # Only want to export routes for workloads.
-  next hop self;    # Disable next hop processing and always advertise our
-                    # local address as nexthop
-  source address {{getenv "IP6"}};  # The local address we use for the TCP connection
-  add paths on;
 }
 {{end}}{{end}}{{end}}
 {{end}}


### PR DESCRIPTION
Extract common config into a template, to reduce duplication
in the bird and bird6 config files.

This change should just be structural, and have no effect on the config that's output by confd.