### PR TITLE
Avoid None being passed to env_to_dictionary

### DIFF
--- a/node/adapter/powerstrip-calico.py
+++ b/node/adapter/powerstrip-calico.py
@@ -144,6 +144,7 @@ class AdapterResource(resource.Resource):
 
             # Attempt to parse out environment variables
             env_list = cont["Config"]["Env"]
+            env_list = env_list if env_list is not None else []
             env_dict = env_to_dictionary(env_list)
             ip_str = env_dict[ENV_IP]
             profile = env_dict.get(ENV_PROFILE, None)


### PR DESCRIPTION
This change ensures that we don't accidentally pass `None` to `env_to_dictionary`.

The other option was to do a short-circuit return in `env_to_dictionary`, but I felt like that was a weirdly general solution, so I decided this ternary approach was better.

Resolves #92.