### PR TITLE
Use nsenter as it is more generic and faster than docker exec

### DIFF
--- a/build_calicoctl/requirements.txt
+++ b/build_calicoctl/requirements.txt
@@ -4,6 +4,7 @@ docopt==0.6.2
 mock==1.0.1
 PyInstaller==2.1
 six==1.9.0
+nsenter==0.1.6
 nose==1.3.1
 
 # Only used inside calicoctl

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#!/usr/bin/env python
 """calicoctl
 
 Override the host:port of the ETCD server by setting the environment variable
@@ -204,7 +205,7 @@ def container_add(container_name, ip, interface):
     pid = info["State"]["Pid"]
     endpoint = netns.set_up_endpoint(ip, pid, next_hops,
                                      veth_name=interface,
-                                     proc_alias="proc")
+                                     proc_alias="/proc")
 
     # Register the endpoint
     client.set_endpoint(hostname, container_id, endpoint)
@@ -904,10 +905,10 @@ def container_ip_add(container_name, ip, version, interface):
 
     try:
         container_pid = info["State"]["Pid"]
-        netns.ensure_namespace_named(container_pid)
         netns.add_ip_to_interface(container_pid,
                                   address,
-                                  interface)
+                                  interface,
+                                  proc_alias="/proc")
 
     except CalledProcessError:
         print "Error updating networking in container. Aborting."
@@ -976,10 +977,10 @@ def container_ip_remove(container_name, ip, version, interface):
 
     try:
         container_pid = info["State"]["Pid"]
-        netns.ensure_namespace_named(container_pid)
         netns.remove_ip_from_interface(container_pid,
                                        address,
-                                       interface)
+                                       interface,
+                                       proc_alias="/proc")
 
     except CalledProcessError:
         print "Error updating networking in container. Aborting."
@@ -1218,6 +1219,5 @@ if __name__ == '__main__':
         print "Unexpected error executing command.\n"
         traceback.print_exc()
         print dir(e)
-        print e.__module__ + "." + e.__class__.__name__
         sys.exit(1)
 

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#!/usr/bin/env python
+
 """calicoctl
 
 Override the host:port of the ETCD server by setting the environment variable

--- a/calicoctl.py
+++ b/calicoctl.py
@@ -416,6 +416,7 @@ def status():
     else:
         print "calico-node container is running. Status: %s" % \
               calico_node_info[0]["Status"]
+
         apt_cmd = docker_client.exec_create("calico-node", ["/bin/bash", "-c",
                                            "apt-cache policy calico-felix"])
         result = re.search(r"Installed: (.*?)\s", docker_client.exec_start(apt_cmd))

--- a/node/adapter/netns.py
+++ b/node/adapter/netns.py
@@ -144,9 +144,10 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
 
     # Provision the networking.  We create a temporary link from the proc
     # alias to the /var/run/netns to provide a named namespace.  If we don't
-    # do this, when run from the calico-node container, the PID of the
-    # container process is not recognised by ip link set <if> netns <pid>
-    # because that uses /proc rather than the proc alias to dereference a PID.
+    # do this, when run from the calico-node container the PID of the
+    # container process is not recognised by `ip link set <if> netns <pid>`
+    # command because that uses /proc rather than the proc alias to
+    # dereference the PID.
     #
     # TODO: Something similar to Namespace() to arbitrarily specify the proc
     # ...   alias for the ip link set command.

--- a/node/adapter/netns.py
+++ b/node/adapter/netns.py
@@ -43,7 +43,7 @@ pid 1
 PREFIX_LEN = {4: 32, 6: 128}
 """The IP address prefix length to assign, by IP version."""
 
-PROC_ALIAS = "proc_host"
+PROC_ALIAS = "/proc_host"
 """The alias for /proc.  This is useful when the filesystem is containerized.
 """
 
@@ -75,16 +75,18 @@ def remove_endpoint(ep_id):
     call("ip link delete %s" % iface, shell=True)
 
 
-def add_ip_to_interface(container_pid, ip, interface_name):
+def add_ip_to_interface(container_pid, ip, interface_name,
+                    proc_alias=PROC_ALIAS):
     """
     Add an IP to an interface in a container.
 
     :param container_pid: The PID and name of the namespace to operate in.
     :param ip: The IPAddress to add.
     :param interface_name: The interface to add the address to.
+    :param proc_alias: The head of the /proc filesystem on the host.
     :return: None. raises CalledProcessError on error.
     """
-    with Namespace(container_pid, 'net', proc="/proc_host"):
+    with Namespace(container_pid, 'net', proc=proc_alias):
         check_call("ip -%(version)s addr add "
                    "%(addr)s/%(len)s dev %(device)s" %
                    {"version": ip.version,
@@ -93,16 +95,18 @@ def add_ip_to_interface(container_pid, ip, interface_name):
                     "device": interface_name},
                    shell=True)
 
-def remove_ip_from_interface(container_pid, ip, interface_name):
+def remove_ip_from_interface(container_pid, ip, interface_name,
+                    proc_alias=PROC_ALIAS):
     """
     Remove an IP from an interface in a container.
 
     :param container_pid: The PID and name of the namespace to operate in.
     :param ip: The IPAddress to remove.
     :param interface_name: The interface to remove the address from.
+    :param proc_alias: The head of the /proc filesystem on the host.
     :return: None. raises CalledProcessError on error.
     """
-    with Namespace(container_pid, 'net', proc="/proc_host"):
+    with Namespace(container_pid, 'net', proc=proc_alias):
         check_call("ip -%(version)s addr del "
                    "%(addr)s/%(len)s dev %(device)s" %
                    {"version": ip.version,
@@ -113,7 +117,6 @@ def remove_ip_from_interface(container_pid, ip, interface_name):
 
 
 def set_up_endpoint(ip, cpid, next_hop_ips,
-                    in_container=False,
                     veth_name=VETH_NAME,
                     proc_alias=PROC_ALIAS):
     """
@@ -124,8 +127,6 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
     :param cpid: The PID of a process currently running in the namespace.
     :param next_hop_ips: Dict of {version: IPAddress} for the next hops of the
     default routes.
-    :param in_container: When True, we assume this program is itself running in
-    a container
     namespace, as opposed to the root namespace.  If so, this method also moves
     the other end of the veth into the root namespace.
     :param veth_name: The name of the interface inside the container namespace,
@@ -141,52 +142,44 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
     iface = IF_PREFIX + ep_id[:11]
     iface_tmp = "tmp" + ep_id[:11]
 
-    # Provision the networking
-    check_call("mkdir -p /var/run/netns", shell=True)
-    check_call("ln -s /%s/%s/ns/net /var/run/netns/%s" % (proc_alias,
-                                                          cpid,
-                                                          cpid),
-               shell=True)
+    # Provision the networking.  We create a temporary link from the proc
+    # alias to the /var/run/netns to provide a named namespace.  If we don't
+    # do this, when run from the calico-node container, the PID of the
+    # container process is not recognised by ip link set <if> netns <pid>
+    # because that uses /proc rather than the proc alias to dereference a PID.
+    #
+    # TODO: Something similar to Namespace() to arbitrarily specify the proc
+    # ...   alias for the ip link set command.
+    try:
+        check_call("mkdir -p /var/run/netns", shell=True)
+        check_call("ln -s %s/%s/ns/net /var/run/netns/pid-%s" %
+                     (proc_alias, cpid, cpid),
+                   shell=True)
+        _log.debug(check_output("ls -l /var/run/netns", shell=True))
 
-    # If running in a container, set up a link to the root netns.
-    if in_container:
-        try:
-            check_call("ln -s /%s/%s/ns/net /var/run/netns/%s" % (proc_alias,
-                                                                  ROOT_NETNS,
-                                                                  ROOT_NETNS),
-                       shell=True)
-        except CalledProcessError:
-            pass  # Only need to do this once.
-    _log.debug(check_output("ls -l /var/run/netns", shell=True))
-
-    # Create the veth pair and move one end into container:
-    check_call("ip link add %s type veth peer name %s" % (iface, iface_tmp),
-               shell=True)
-    check_call("ip link set %s up" % iface, shell=True)
-    check_call("ip link set %s netns %s" % (iface_tmp, cpid), shell=True)
-    _log.debug(check_output("ip link", shell=True))
+        # Create the veth pair and move one end into container:
+        check_call("ip link add %s type veth peer name %s" %
+                     (iface, iface_tmp),
+                   shell=True)
+        check_call("ip link set %s up" % iface, shell=True)
+        check_call("ip link set %s netns pid-%s" % (iface_tmp, cpid),
+                   shell=True)
+        _log.debug(check_output("ip link", shell=True))
+    finally:
+        check_call("rm /var/run/netns/pid-%s" % cpid, shell=True)
 
     # Rename within the container to something sensible.
-    with Namespace(cpid, 'net', proc="/proc_host"):
+    with Namespace(cpid, 'net', proc=proc_alias):
         check_call("ip link set dev %s name %s" % (iface_tmp,veth_name),
                    shell=True)
         check_call("ip link set %s up" % (veth_name), shell=True)
 
-        # If in container, the iface end of the veth pair will be in the container
-        # namespace.  We need to move it to the root namespace so it will
-        # participate in routing.
-    if in_container:
-        # Move the other end of the veth pair into the root namespace
-        check_call("ip link set %s netns %s" % (iface, ROOT_NETNS), shell=True)
-        with Namespace(ROOT_NETNS, 'net', proc="/proc_host"):
-            check_call("ip link set %s up" % (iface), shell=True)
-
     # Add an IP address.
-    add_ip_to_interface(cpid, ip, veth_name)
+    add_ip_to_interface(cpid, ip, veth_name, proc_alias=proc_alias)
 
     # Connected route to next hop & default route.
     next_hop = next_hop_ips[ip.version]
-    with Namespace(cpid, 'net', proc="/proc_host"):
+    with Namespace(cpid, 'net', proc=proc_alias):
         check_call("ip -%(version)s route replace"
                    " %(next_hop)s dev %(device)s" %
                    {"version": ip.version,
@@ -215,16 +208,3 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
         ep.ipv6_nets.add(network)
         ep.ipv6_gateway = next_hop
     return ep
-
-
-def ensure_namespace_named(container_pid):
-    """
-    Ensures that a namespace is named. Idempotent.
-
-    :param container_pid: The container_pid to name.
-    :return: raises CalledProcessError if naming the ns fails.
-    """
-    if not os.path.islink("/var/run/netns/%s" % container_pid):
-        check_call("ln -s /proc/%s/ns/net /var/run/netns/%s" % (container_pid,
-                                                                container_pid),
-                   shell=True)

--- a/node/adapter/requirements.txt
+++ b/node/adapter/requirements.txt
@@ -18,6 +18,7 @@ six==1.9.0
 websocket-client==0.30.0
 zope.interface==4.1.2
 simplejson==3.6.5
+nsenter==0.1.6
 
 # We use this version because python-etcd depends on it.
 urllib3==1.7.1

--- a/tests/fv/mainline.sh
+++ b/tests/fv/mainline.sh
@@ -2,12 +2,14 @@
 set -e
 set -x
 
-# Execute show commands
+#CALICOCTL_CMD="python calicoctl.py"
+CALICOCTL_CMD="dist/calicoctl"
+
 show_commands() {
-dist/calicoctl status
-dist/calicoctl shownodes --detailed
-dist/calicoctl pool show
-dist/calicoctl profile show --detailed
+$CALICOCTL_CMD status
+$CALICOCTL_CMD shownodes --detailed
+$CALICOCTL_CMD ipv4 pool show
+$CALICOCTL_CMD profile show --detailed
 }
 
 # Run the mainline test.
@@ -19,11 +21,12 @@ cfg_ip2=$2
 # Set it up
 docker rm -f node1 node2 etcd || true
 docker run -d --net=host --name etcd quay.io/coreos/etcd:v2.0.10
-dist/calicoctl reset || true
+docker run --rm  -v `pwd`:/target jpetazzo/nsenter || true
+$CALICOCTL_CMD reset || true
 
 show_commands
-dist/calicoctl node --ip=127.0.0.1
-dist/calicoctl profile add TEST_GROUP
+$CALICOCTL_CMD node --ip=127.0.0.1
+$CALICOCTL_CMD profile add TEST_GROUP
 
 # Add endpoints
 export DOCKER_HOST=localhost:2377
@@ -46,42 +49,45 @@ node2_ip="${node2_ip%\"*}"
 echo "Node 2 IP address is $node2_ip"
 
 # Configure the nodes with the same profiles.
-dist/calicoctl profile TEST_GROUP member add node1
-dist/calicoctl profile TEST_GROUP member add node2
+$CALICOCTL_CMD profile TEST_GROUP member add node1
+$CALICOCTL_CMD profile TEST_GROUP member add node2
 
 # Check the config looks good - standard set of show commands plus the
 # non-detailed ones for completeness.
 show_commands
-dist/calicoctl shownodes
-dist/calicoctl profile show
+$CALICOCTL_CMD shownodes
+$CALICOCTL_CMD profile show
+
+node1=$(docker inspect --format {{.State.Pid}} node1)
+node2=$(docker inspect --format {{.State.Pid}} node2)
 
 # Check it works
-while ! docker exec node1 ping $node2_ip -c 1 -W 1; do
+while ! ./nsenter -t $node1 ping $node2_ip -c 1 -W 1; do
 echo "Waiting for network to come up"
   sleep 1
 done
 
-docker exec node1 ping $node1_ip -c 1
-docker exec node1 ping $node2_ip -c 1
-docker exec node2 ping $node1_ip -c 1
-docker exec node2 ping $node2_ip -c 1
+./nsenter -t $node1 ping $node1_ip -c 1
+./nsenter -t $node1 ping $node2_ip -c 1
+./nsenter -t $node2 ping $node1_ip -c 1
+./nsenter -t $node2 ping $node2_ip -c 1
 
 # Record diags - works, but it's just s bit slow.
-#dist/calicoctl diags
+#$CALICOCTL_CMD diags
 
 # Tear it down
-dist/calicoctl profile remove TEST_GROUP
+$CALICOCTL_CMD profile remove TEST_GROUP
 show_commands
 
-dist/calicoctl container remove node1
-dist/calicoctl container remove node2
+$CALICOCTL_CMD container remove node1
+$CALICOCTL_CMD container remove node2
 show_commands
 
-dist/calicoctl pool remove 192.168.0.0/16
+$CALICOCTL_CMD pool remove 192.168.0.0/16
 show_commands
 
 export DOCKER_HOST=
-dist/calicoctl node stop
+$CALICOCTL_CMD node stop
 show_commands
 }
 

--- a/tests/fv/mainline.sh
+++ b/tests/fv/mainline.sh
@@ -8,7 +8,7 @@ CALICOCTL_CMD="dist/calicoctl"
 show_commands() {
 $CALICOCTL_CMD status
 $CALICOCTL_CMD shownodes --detailed
-$CALICOCTL_CMD ipv4 pool show
+$CALICOCTL_CMD pool show
 $CALICOCTL_CMD profile show --detailed
 }
 


### PR DESCRIPTION
Also introduces some test refactoring,

Currently breaks on circle CI. We should run the tests in a container so it doesn't break...