### PR TITLE
Make bird aware of device routes for all non-calico interfaces

### DIFF
--- a/node/templates/bird.cfg.template
+++ b/node/templates/bird.cfg.template
@@ -28,7 +28,7 @@ protocol device {
 
 protocol direct {
    debug all;
-   interface "eth*", "em*", "ens*";
+   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
 # Template for all BGP clients


### PR DESCRIPTION
Potentially fixes #122