### PR TITLE
Add ability to reinstate networking to container

### DIFF
--- a/calicoctl.py
+++ b/calicoctl.py
@@ -108,6 +108,7 @@ def get_container_info_or_exit(container_name):
         sys.exit(1)
     return info
 
+
 def get_container_id(container_name):
     """
     Get the full container ID from a partial ID or name.

--- a/node/adapter/datastore.py
+++ b/node/adapter/datastore.py
@@ -31,6 +31,10 @@ prefix that appears in all Calico interface names in the root namespace. e.g.
 cali123456789ab.
 """
 
+VETH_NAME = "eth1"
+"""The name to give to the veth in the target container's namespace. Default
+to eth1 because eth0 could be in use"""
+
 
 def handle_errors(fn):
     """
@@ -174,10 +178,17 @@ class Endpoint(object):
     @classmethod
     def from_json(cls, ep_id, json_str):
         json_dict = json.loads(json_str)
+
+        # If there is no container if_name sepcified, assume the default
+        # VETH_NAME.  For containers created prior to this information being
+        # stored, it will be possible to restart the containers, but the
+        # interface may be named differently.
+        if_name = json_dict.get("container:if_name", VETH_NAME)
+
         ep = cls(ep_id=ep_id,
                  state=json_dict["state"],
                  mac=json_dict["mac"],
-                 if_name=json_dict["container:if_name"])
+                 if_name= if_name)
         for net in json_dict["ipv4_nets"]:
             ep.ipv4_nets.add(IPNetwork(net))
         for net in json_dict["ipv6_nets"]:

--- a/node/adapter/datastore.py
+++ b/node/adapter/datastore.py
@@ -736,7 +736,7 @@ class DatastoreClient(object):
     @handle_errors
     def get_endpoints(self, hostname, container_id):
         """
-        Get all of Endpoints for a container.
+        Get all of the Endpoints for a container.
 
         :param hostname: The hostname that the endpoint lives on.
         :param container_id: The container that the endpoint belongs to.
@@ -756,11 +756,7 @@ class DatastoreClient(object):
         for endpoint in endpoints:
             (_, _, _, _, _, _, _, _, _, endpoint_id) = \
                                                  endpoint.key.split("/", 9)
-            ep_path = ENDPOINT_PATH % {"hostname": hostname,
-                                       "container_id": container_id,
-                                       "endpoint_id": endpoint_id}
-            ep_json = self.etcd_client.read(ep_path).value
-            eps.append(Endpoint.from_json(endpoint_id, ep_json))
+            eps.append(Endpoint.from_json(endpoint_id, endpoint.value))
         return eps
 
     @handle_errors

--- a/node/adapter/datastore.py
+++ b/node/adapter/datastore.py
@@ -145,10 +145,11 @@ class Rules(namedtuple("Rules", ["id", "inbound_rules", "outbound_rules"])):
 
 class Endpoint(object):
 
-    def __init__(self, ep_id, state, mac):
+    def __init__(self, ep_id, state, mac, if_name):
         self.ep_id = ep_id
         self.state = state
         self.mac = mac
+        self.if_name = if_name
 
         self.profile_id = None
         self.ipv4_nets = set()
@@ -160,6 +161,7 @@ class Endpoint(object):
         json_dict = {"state": self.state,
                      "name": IF_PREFIX + self.ep_id[:11],
                      "mac": self.mac,
+                     "container:if_name": self.if_name,
                      "profile_id": self.profile_id,
                      "ipv4_nets": sorted([str(net) for net in self.ipv4_nets]),
                      "ipv6_nets": sorted([str(net) for net in self.ipv6_nets]),
@@ -174,7 +176,8 @@ class Endpoint(object):
         json_dict = json.loads(json_str)
         ep = cls(ep_id=ep_id,
                  state=json_dict["state"],
-                 mac=json_dict["mac"])
+                 mac=json_dict["mac"],
+                 if_name=json_dict["container:if_name"])
         for net in json_dict["ipv4_nets"]:
             ep.ipv4_nets.add(IPNetwork(net))
         for net in json_dict["ipv6_nets"]:
@@ -193,6 +196,7 @@ class Endpoint(object):
             return NotImplemented
         return (self.ep_id == other.ep_id and
                 self.state == other.state and
+                self.if_name == other.if_name and
                 self.mac == other.mac and
                 self.profile_id == other.profile_id and
                 self.ipv4_nets == other.ipv4_nets and
@@ -728,6 +732,36 @@ class DatastoreClient(object):
         self.etcd_client.write(ep_path,
                                new_endpoint.to_json(),
                                prevValue=old_endpoint.to_json())
+
+    @handle_errors
+    def get_endpoints(self, hostname, container_id):
+        """
+        Get all of Endpoints for a container.
+
+        :param hostname: The hostname that the endpoint lives on.
+        :param container_id: The container that the endpoint belongs to.
+        :return:  a list of Endpoint Object
+        """
+        eps_path = LOCAL_ENDPOINTS_PATH % {"hostname": hostname,
+                                          "container_id": container_id}
+        try:
+            endpoints = self.etcd_client.read(eps_path).leaves
+        except EtcdKeyNotFound:
+            # Re-raise with better message
+            raise KeyError("Container with ID %s was not found." %
+                           container_id)
+
+        # Extract all of the endpoints.
+        eps = []
+        for endpoint in endpoints:
+            (_, _, _, _, _, _, _, _, _, endpoint_id) = \
+                                                 endpoint.key.split("/", 9)
+            ep_path = ENDPOINT_PATH % {"hostname": hostname,
+                                       "container_id": container_id,
+                                       "endpoint_id": endpoint_id}
+            ep_json = self.etcd_client.read(ep_path).value
+            eps.append(Endpoint.from_json(endpoint_id, ep_json))
+        return eps
 
     @handle_errors
     def get_hosts(self):

--- a/node/adapter/netns.py
+++ b/node/adapter/netns.py
@@ -23,16 +23,12 @@ import uuid
 
 from netaddr import IPNetwork, IPAddress
 
-from datastore import Endpoint, IF_PREFIX
+from datastore import Endpoint, IF_PREFIX, VETH_NAME
 
 
 _log = logging.getLogger(__name__)
 
 HOSTNAME = socket.gethostname()
-
-VETH_NAME = "eth1"
-"""The name to give to the veth in the target container's namespace. Default
-to eth1 because eth0 could be in use"""
 
 ROOT_NETNS = "1"
 """The pid of the root namespace.  On almost all systems, the init system is
@@ -79,10 +75,10 @@ def add_ip_to_interface(container_pid, ip, interface_name,
     """
     Add an IP to an interface in a container.
 
-    :param container_pid: The PID and name of the namespace to operate in.
+    :param container_pid: The PID of the namespace to operate in.
     :param ip: The IPAddress to add.
     :param interface_name: The interface to add the address to.
-    :param proc_alias: The head of the /proc filesystem on the host.
+    :param proc_alias: The location of the /proc filesystem on the host.
     :return: None. raises CalledProcessError on error.
     """
     with NamedNamespace(container_pid, proc=proc_alias) as ns:
@@ -100,10 +96,10 @@ def remove_ip_from_interface(container_pid, ip, interface_name,
     """
     Remove an IP from an interface in a container.
 
-    :param container_pid: The PID and name of the namespace to operate in.
+    :param container_pid: The PID of the namespace to operate in.
     :param ip: The IPAddress to remove.
     :param interface_name: The interface to remove the address from.
-    :param proc_alias: The head of the /proc filesystem on the host.
+    :param proc_alias: The location of the /proc filesystem on the host.
     :return: None. raises CalledProcessError on error.
     """
     with NamedNamespace(container_pid, proc=proc_alias) as ns:
@@ -132,7 +128,7 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
     method also moves the other end of the veth into the root namespace.
     :param veth_name: The name of the interface inside the container namespace,
     e.g. eth1
-    :param proc_alias: The head of the /proc filesystem on the host.
+    :param proc_alias: The location of the /proc filesystem on the host.
     :param ep_id: The endpoint ID to use.  Set to None if this is a new
     endpoint, or set to the existing endpoint ID that is being re-added.
     :param mac: The interface MAC to use.  Set to None to auto assign a MAC.
@@ -213,11 +209,11 @@ def reinstate_endpoint(cpid, old_endpoint, next_hop_ips,
                        proc_alias=PROC_ALIAS):
     """
     Re-instate and endpoint that has been removed.
-    :param cpid: The PID and name of the namespace to operate in.
+    :param cpid: The PID of the namespace to operate in.
     :param old_endpoint: The old endpoint that is being re-instated.
     :param next_hop_ips: Dict of {version: IPAddress} for the next hops of the
     default routes namespace.
-    :param proc_alias: The head of the /proc filesystem on the host.
+    :param proc_alias: The location of the /proc filesystem on the host.
     :return: A new Endpoint replacing the old one.
     """
     nets = old_endpoint.ipv4_nets | old_endpoint.ipv6_nets

--- a/node/adapter/netns.py
+++ b/node/adapter/netns.py
@@ -158,7 +158,6 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
                    shell=True)
         _log.debug(check_output("ip link", shell=True))
 
-    with Namespace(cpid, 'net', proc=proc_alias):
         if mac:
             ns.check_call("ip link set dev %s name %s address %s" %
                             (iface_tmp, veth_name, str(mac)),

--- a/node/adapter/netns.py
+++ b/node/adapter/netns.py
@@ -119,7 +119,8 @@ def remove_ip_from_interface(container_pid, ip, interface_name,
 def set_up_endpoint(ip, cpid, next_hop_ips,
                     veth_name=VETH_NAME,
                     proc_alias=PROC_ALIAS,
-                    ep_id=None):
+                    ep_id=None,
+                    mac=None):
     """
     Set up an endpoint (veth) in the network namespace identified by the PID.
 
@@ -134,6 +135,7 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
     :param proc_alias: The head of the /proc filesystem on the host.
     :param ep_id: The endpoint ID to use.  Set to None if this is a new
     endpoint, or set to the existing endpoint ID that is being re-added.
+    :param mac: The interface MAC to use.  Set to None to auto assign a MAC.
     :return: An Endpoint describing the veth just created.
     """
     assert isinstance(ip, IPAddress)
@@ -160,10 +162,16 @@ def set_up_endpoint(ip, cpid, next_hop_ips,
                    shell=True)
         _log.debug(check_output("ip link", shell=True))
 
-        # Rename within the container to something sensible.
-        ns.check_call("ip link set dev %s name %s" % (iface_tmp,veth_name),
-                      shell=True)
-        ns.check_call("ip link set %s up" % (veth_name), shell=True)
+    with Namespace(cpid, 'net', proc=proc_alias):
+        if mac:
+            ns.check_call("ip link set dev %s name %s address %s" %
+                            (iface_tmp, veth_name, str(mac)),
+                          shell=True)
+        else:
+            ns.check_call("ip link set dev %s name %s" %
+                            (iface_tmp, veth_name),
+                          shell=True)
+        ns.check_call("ip link set %s up" % veth_name, shell=True)
 
     # Add an IP address.
     add_ip_to_interface(cpid, ip, veth_name, proc_alias=proc_alias)
@@ -220,7 +228,8 @@ def reinstate_endpoint(cpid, old_endpoint, next_hop_ips,
                                    next_hop_ips=next_hop_ips,
                                    veth_name=if_name,
                                    proc_alias=proc_alias,
-                                   ep_id=old_endpoint.ep_id)
+                                   ep_id=old_endpoint.ep_id,
+                                   mac=old_endpoint.mac)
     for net in nets:
         add_ip_to_interface(cpid, net.ip, if_name, proc_alias=proc_alias)
 

--- a/node/adapter/powerstrip-calico.py
+++ b/node/adapter/powerstrip-calico.py
@@ -124,15 +124,23 @@ class AdapterResource(resource.Resource):
             request_uri = client_request['Request']
             request_path = request_uri.split('/')
 
-            # Extract the container ID and request type.
+            # Extract the container ID or name and request type.
             # TODO better URI parsing
-            (_, version, _, cid, ctype) = request_uri.split("/", 4)
+            (_, version, _, cid_or_name, ctype) = request_uri.split("/", 4)
             _log.info("Request parameters: version:%s; cid:%s; ctype:%s",
-                      version, cid, ctype)
+                      version, cid_or_name, ctype)
+
+            # Get the actual container ID, the URL may contain the name or
+            # a short ID.
+            cont = self.docker.inspect_container(cid_or_name)
+            _log.debug("Container info: %s", cont)
+            cid = cont["Id"]
+            _log.debug("Container ID: %s", cid)
+
             if ctype == u'start':
                 # /version/containers/id/start
                 _log.debug('Intercepted container start request')
-                self._install_endpoint(client_request, cid)
+                self._install_or_reinstall_endpoints(client_request, cont, cid)
             elif ctype== 'json':
                 # /version/containers/*/json
                 _log.debug('Intercepted container json request')
@@ -149,23 +157,41 @@ class AdapterResource(resource.Resource):
             _log.debug("Returning output:\n%s", output)
             return output
 
-    def _install_endpoint(self, client_request, cid):
+    def _install_or_reinstall_endpoints(self, client_request, cont, cid):
+        """
+        Install or reinstall Calico endpoints based on whether we are
+        restarting a container.
+-       :param client_request: Powerstrip ClientRequest object as dictionary
+                               from JSON.
+        :param cont: The Docker container dictionary.
+        :param cid: The ID of the container to install an endpoint in.
+        :returns: None
+        """
+        # Grab the running pid from Docker
+        pid = cont["State"]["Pid"]
+        _log.debug('Container PID: %s', pid)
+
+        # Grab the list of endpoints, if they exist.
+        try:
+            eps = self.datastore.get_endpoints(hostname, cid)
+            self._reinstall_endpoints(cid, pid, eps)
+        except KeyError:
+            self._install_endpoint(client_request, cont, cid, pid)
+        return
+
+    def _install_endpoint(self, client_request, cont, cid, pid):
         """
         Install a Calico endpoint (veth) in the container referenced in the
         client request object.
 -       :param client_request: Powerstrip ClientRequest object as dictionary
                                from JSON.
+        :param cont: The Docker container dictionary.
         :param cid: The ID of the container to install an endpoint in.
+        :param pid: The PID of the container process.
         :returns: None
         """
         try:
             _log.debug("Installing endpoint for cid %s", cid)
-
-            # Grab the running pid from Docker
-            cont = self.docker.inspect_container(cid)
-            _log.debug("Container info: %s", cont)
-            pid = cont["State"]["Pid"]
-            _log.debug('Container PID: %s', pid)
 
             # Attempt to parse out environment variables
             env_list = cont["Config"]["Env"]
@@ -224,7 +250,27 @@ class AdapterResource(resource.Resource):
 
         return
 
-    def _update_container_info(self, cid_or_name, server_response):
+    def _reinstall_endpoints(self, cid, pid, eps):
+        """
+        Install a Calico endpoint (veth) in the container referenced in the
+        client request object.
+        :param cid: The ID of the container to install an endpoint in.
+        :param pid: The PID of the container process.
+        :param eps: The container endpoints.
+        :returns: None
+        """
+        _log.debug("Re-install endpoints for container %s", cid)
+        next_hop_ips = self.datastore.get_default_next_hops(hostname)
+        for old_endpoint in eps:
+            new_endpoint = netns.reinstate_endpoint(pid, old_endpoint,
+                                                    next_hop_ips)
+            self.datastore.update_endpoint(hostname, cid,
+                                           old_endpoint, new_endpoint)
+
+        _log.info("Finished network for container %s", cid)
+        return
+
+    def _update_container_info(self, cid, server_response):
         """
         Update the response for a */container/*/json (docker inspect) request.
 
@@ -234,18 +280,13 @@ class AdapterResource(resource.Resource):
 
         Insert the IP for this container into the config dict.
 
-        :param str cid_or_name: The name or ID of the container to update.
-        :param dict server_response: The response from the Docker API, to be
-                                     be updated.
+        :param cid: The ID of the container to install an endpoint in.
+        :param server_response: The response from the Docker API, to be
+                                 be updated.
         """
         _log.debug('Getting container config from etcd')
 
         try:
-            cont = self.docker.inspect_container(cid_or_name)
-            _log.debug("Container info: %s", cont)
-            cid = cont["Id"]
-            _log.debug("Container ID: %s", cid)
-
             # Get a single endpoint ID from the container, and use this to
             # get the Endpoint.
             ep_id = self.datastore.get_ep_id_from_cont(hostname, cid)

--- a/tests/fv/add_ip.sh
+++ b/tests/fv/add_ip.sh
@@ -45,6 +45,26 @@ docker exec node2 ping 192.168.2.1 -c 1
 docker exec node2 ping 192.168.3.1 -c 1
 $CALICO shownodes --detailed
 
+# Now stop and restart node 1 and node 2.
+sudo docker -H=localhost:2377 stop node1
+sudo docker -H=localhost:2377 stop node2
+sudo docker -H=localhost:2377 start node1
+sudo docker -H=localhost:2377 start node2
+
+# Wait for the network to come up.
+while ! docker exec node1 ping 192.168.1.2 -c 1 -W 1; do
+echo "Waiting for network to come up"
+  sleep 1
+done
+
+# Test pings between the IPs.
+docker exec node1 ping 192.168.1.2 -c 1
+docker exec node1 ping 192.168.2.2 -c 1
+docker exec node2 ping 192.168.1.1 -c 1
+docker exec node2 ping 192.168.2.1 -c 1
+docker exec node2 ping 192.168.3.1 -c 1
+$CALICO shownodes --detailed
+
 # Now remove and check pings to the removed addresses no longer work.
 $CALICO container node1 ip remove 192.168.2.1
 $CALICO container node2 ip remove 192.168.2.2 --interface=hello

--- a/tests/unit/datastore_test.py
+++ b/tests/unit/datastore_test.py
@@ -21,6 +21,7 @@ TEST_HOST = "TEST_HOST"
 TEST_PROFILE = "TEST"
 TEST_CONT_ID = "1234"
 TEST_ENDPOINT_ID = "1234567890ab"
+TEST_ENDPOINT_ID2 = "90abcdef1234"
 TEST_HOST_PATH = CALICO_V_PATH + "/host/TEST_HOST"
 IPV4_POOLS_PATH = CALICO_V_PATH + "/ipam/v4/pool/"
 IPV6_POOLS_PATH = CALICO_V_PATH + "/ipam/v6/pool/"
@@ -37,15 +38,15 @@ TEST_CONT_PATH = CALICO_V_PATH + "/host/TEST_HOST/workload/docker/1234/"
 CONFIG_PATH = CALICO_V_PATH + "/config/"
 
 # 4 endpoints, with 2 TEST profile and 2 UNIT profile.
-EP_56 = Endpoint("567890abcdef", "active", "11-22-33-44-55-66")
+EP_56 = Endpoint("567890abcdef", "active", "AA-22-BB-44-CC-66", if_name="eth0")
 EP_56.profile_id = "TEST"
-EP_78 = Endpoint("7890abcdef12", "active", "11-22-33-44-55-66")
+EP_78 = Endpoint("7890abcdef12", "active", "11-AA-33-BB-55-CC", if_name="eth0")
 EP_78.profile_id = "TEST"
-EP_90 = Endpoint("90abcdef1234", "active", "11-22-33-44-55-66")
+EP_90 = Endpoint("90abcdef1234", "active", "1A-2B-3C-4D-5E-6E", if_name="eth0")
 EP_90.profile_id = "UNIT"
-EP_12 = Endpoint(TEST_ENDPOINT_ID, "active", "11-22-33-44-55-66")
+EP_12 = Endpoint(TEST_ENDPOINT_ID, "active", "11-22-33-44-55-66",
+                 if_name="eth0")
 EP_12.profile_id = "UNIT"
-
 
 class TestRule(unittest.TestCase):
 
@@ -133,7 +134,8 @@ class TestEndpoint(unittest.TestCase):
         """
         endpoint1 = Endpoint("aabbccddeeff112233",
                              "active",
-                             "11-22-33-44-55-66")
+                             "11-22-33-44-55-66",
+                             if_name="eth0")
         assert_equal(endpoint1.ep_id, "aabbccddeeff112233")
         assert_equal(endpoint1.state, "active")
         assert_equal(endpoint1.mac, "11-22-33-44-55-66")
@@ -141,6 +143,7 @@ class TestEndpoint(unittest.TestCase):
         expected = {"state": "active",
                     "name": "caliaabbccddeef",
                     "mac": "11-22-33-44-55-66",
+                    "container:if_name": "eth0",
                     "profile_id": None,
                     "ipv4_nets": [],
                     "ipv6_nets": [],
@@ -166,6 +169,7 @@ class TestEndpoint(unittest.TestCase):
         expected = {"state": "active",
                     "name": "caliaabbccddeef",
                     "mac": "11-22-33-44-55-66",
+                    "container:if_name": "eth0",
                     "profile_id": "TEST23",
                     "ipv4_nets": ["192.168.3.2/32", "10.3.4.23/32"],
                     "ipv6_nets": ["fd20::4:2:1/128"],
@@ -198,10 +202,12 @@ class TestEndpoint(unittest.TestCase):
         """
         endpoint1 = Endpoint("aabbccddeeff112233",
                              "active",
-                             "11-22-33-44-55-66")
+                             "11-22-33-44-55-66",
+                             if_name="eth0")
         endpoint2 = Endpoint("aabbccddeeff112233",
                              "inactive",
-                             "11-22-33-44-55-66")
+                             "11-22-33-44-55-66",
+                             if_name="eth0")
         endpoint3 = endpoint1.copy()
 
         assert_equal(endpoint1, endpoint3)
@@ -658,7 +664,8 @@ class TestDatastoreClient(unittest.TestCase):
         """
         Test get_endpoint() for an endpoint that exists.
         """
-        ep = Endpoint(TEST_ENDPOINT_ID, "active", "11-22-33-44-55-66")
+        ep = Endpoint(TEST_ENDPOINT_ID, "active", "11-22-33-44-55-66",
+                      if_name="eth1")
         self.etcd_client.read.side_effect = mock_read_for_endpoint(ep)
         ep2 = self.datastore.get_endpoint(TEST_HOST,
                                           TEST_CONT_ID,
@@ -720,6 +727,30 @@ class TestDatastoreClient(unittest.TestCase):
         self.etcd_client.read.side_effect = EtcdKeyNotFound
         assert_raises(KeyError,
                       self.datastore.get_ep_id_from_cont,
+                      TEST_HOST, TEST_CONT_ID)
+
+    def test_get_endpoints_exists(self):
+        """
+        Test get_endpoints() for a container that exists.
+        """
+        self.etcd_client.read.side_effect = mock_read_2_ep_for_cont
+        eps = self.datastore.get_endpoints(TEST_HOST, TEST_CONT_ID)
+        assert_equal(len(eps), 2)
+        assert_equal(eps[0].to_json(), EP_12.to_json())
+        assert_equal(eps[0].ep_id, EP_12.ep_id)
+        assert_equal(eps[1].to_json(), EP_78.to_json())
+        assert_equal(eps[1].ep_id, EP_78.ep_id)
+
+    def test_get_endpoints_doesnt_exist(self):
+        """
+        Test get_endpoints() for a container that doesn't exist.
+        """
+        def mock_read(path):
+            assert_equal(path, TEST_CONT_ENDPOINT_PATH)
+            raise EtcdKeyNotFound()
+        self.etcd_client.read.side_effect = mock_read
+        assert_raises(KeyError,
+                      self.datastore.get_endpoints,
                       TEST_HOST, TEST_CONT_ID)
 
     def test_add_workload_to_profile(self):
@@ -1104,7 +1135,7 @@ def mock_read_2_ep_for_cont(path):
     specs = [
         (CALICO_V_PATH + "/host/TEST_HOST/workload/docker/1234/endpoint/1234567890ab",
          EP_12.to_json()),
-        (CALICO_V_PATH + "/host/TEST_HOST/workload/docker/1234/endpoint/90abcdef1234",
+        (CALICO_V_PATH + "/host/TEST_HOST/workload/docker/1234/endpoint/7890abcdef12",
          EP_78.to_json())
     ]
     for spec in specs:


### PR DESCRIPTION
This doesn't work yet as it uncovers a bug in Felix where Felix does not update the ARP cache for a MAC change.

See: https://github.com/Metaswitch/calico/issues/549

We could work around it by deleting the endpoint and creating a new endpoint - but I don't like that as it's not an atomic operation.  That said, it would be a simple temporary solution.

