### PR TITLE
Fix create_binary build permission issues.

### DIFF
--- a/build_calicoctl/Dockerfile
+++ b/build_calicoctl/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install -r requirements.txt
 
 # Can't run pyinstaller as root so add a user.
 RUN useradd -d /home/user -m -s /bin/bash user
-RUN chown -R user /code/
+RUN chown -R user:user /code/
 USER user
 # The HOME env var should be set automatically, but for some reason it's not...
 ENV HOME /home/user

--- a/create_binary.sh
+++ b/create_binary.sh
@@ -22,7 +22,8 @@ docker rm -f pyinstaller || true
 docker rm -f docopt || true
 # mount calico_containers and dist under /code work directory.  Don't use /code
 # as the mountpoint directly since the host permissions may not allow the
-# `user` account in the container to write to it.docker run -v `pwd`/calico_containers:/code/calico_containers \
+# `user` account in the container to write to it.
+docker run -v `pwd`/calico_containers:/code/calico_containers \
  -v `pwd`/dist:/code/dist --name docopt calico-build \
  docopt-completion --manual-bash dist/calicoctl
 docker rm -f docopt || true

--- a/create_binary.sh
+++ b/create_binary.sh
@@ -28,8 +28,5 @@ docker run -v `pwd`/calico_containers:/code/calico_containers \
  docopt-completion --manual-bash dist/calicoctl
 docker rm -f docopt || true
 
-
-mv calicoctl.sh dist
-
 echo "Build output is in dist/"
 echo "Copy dist/calicoctl.sh to /etc/bash_completion.d/ to get bash completion"

--- a/create_binary.sh
+++ b/create_binary.sh
@@ -11,12 +11,19 @@ mkdir -p `pwd`/dist
 chmod 777 `pwd`/dist
 
 docker rm -f pyinstaller || true
-docker run -v `pwd`:/code --name pyinstaller calico-build \
+# mount calico_containers and dist under /code work directory.  Don't use /code
+# as the mountpoint directly since the host permissions may not allow the
+# `user` account in the container to write to it.
+docker run -v `pwd`/calico_containers:/code/calico_containers \
+ -v `pwd`/dist:/code/dist --name pyinstaller calico-build \
  pyinstaller calico_containers/calicoctl.py -a -F -s --clean
 docker rm -f pyinstaller || true
 
 docker rm -f docopt || true
-docker run -v `pwd`/:/code --name docopt calico-build \
+# mount calico_containers and dist under /code work directory.  Don't use /code
+# as the mountpoint directly since the host permissions may not allow the
+# `user` account in the container to write to it.docker run -v `pwd`/calico_containers:/code/calico_containers \
+ -v `pwd`/dist:/code/dist --name docopt calico-build \
  docopt-completion --manual-bash dist/calicoctl
 docker rm -f docopt || true
 


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
File "/usr/local/bin/pyinstaller", line 9, in <module>
load_entry_point('PyInstaller==2.1', 'console_scripts', 'pyinstaller')()
File "/usr/local/lib/python2.7/dist-packages/PyInstaller/main.py", line 86, in run
spec_file = run_makespec(opts, args)
File "/usr/local/lib/python2.7/dist-packages/PyInstaller/main.py", line 40, in run_makespec
spec_file = PyInstaller.makespec.main(args, **opts.__dict__)
File "/usr/local/lib/python2.7/dist-packages/PyInstaller/makespec.py", line 322, in main
specfile = open(specfnm, 'w')
IOError: [Errno 13] Permission denied: '/code/calicoctl.spec'
```

Root cause is that the `create_binary.sh` script mounts the project root as `/code` inside the build container.  However, the user account inside the container may not have permission to write to this directory.

This worked for a lot of people's boxes because of a coincidence: the UID of the user trying to build is 1000, which is the same UID as the `user` account created inside the container.  If the user trying to build isn't UID 1000, they hit permission errors.

Solution is not to mount the whole root directory to `/code`.  Instead, mount `calico_containers` to `/code/calico_containers`, which just needs read access.  Mount `dist` to `/code/dist` as the output directory.  This gets set with 777 permissions, so the container use can write to it.