### PR TITLE
Run calicoctl with python

### DIFF
--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -60,13 +60,14 @@ from netaddr import IPNetwork, IPAddress
 from netaddr.core import AddrFormatError
 from prettytable import PrettyTable
 
-from calico_containers.adapter.datastore import (ETCD_AUTHORITY_ENV,
-                                                 ETCD_AUTHORITY_DEFAULT,
-                                                 Rules,
-                                                 DataStoreError)
-from calico_containers.adapter.docker_restart import REAL_SOCK, POWERSTRIP_SOCK
-from calico_containers.adapter.ipam import IPAMClient
-from calico_containers.adapter import netns, docker_restart
+from adapter.datastore import (ETCD_AUTHORITY_ENV,
+                               ETCD_AUTHORITY_DEFAULT,
+                               Rules,
+                               DataStoreError)
+from adapter.docker_restart import REAL_SOCK, POWERSTRIP_SOCK
+from adapter.ipam import IPAMClient
+from adapter import netns, docker_restart
+
 from requests.exceptions import ConnectionError
 from urllib3.exceptions import MaxRetryError
 

--- a/create_binary.sh
+++ b/create_binary.sh
@@ -11,7 +11,13 @@ mkdir -p `pwd`/dist
 chmod 777 `pwd`/dist
 
 docker rm -f pyinstaller || true
-docker run -v `pwd`:/code --name pyinstaller calico-build \
+# mount calico_containers and dist under /code work directory.  Don't use /code
+# as the mountpoint directly since the host permissions may not allow the
+# `user` account in the container to write to it.
+docker run -v `pwd`/calico_containers:/code/calico_containers \
+ -v `pwd`/dist:/code/dist --name pyinstaller \
+ -e PYTHONPATH=/code/calico_containers \
+ calico-build \
  pyinstaller calico_containers/calicoctl.py -a -F -s --clean
 docker rm -f pyinstaller || true
 

--- a/run_sts.sh
+++ b/run_sts.sh
@@ -10,7 +10,7 @@ nosetests calico_containers/tests/st
 
 # Run the STs. Need to run from the /code directory since the tests expect
 # to be run from the root of the codebase.
-docker run --privileged -v `pwd`:/code --name host1 -tid jpetazzo/dind
+docker run --privileged -v `pwd`/calico_containers:/code/calico_containers --name host1 -tid jpetazzo/dind
 docker exec -t host1 bash -c \
  'while ! docker ps; do sleep 1; done && \
  docker load --input /code/calico-node.tar && \

--- a/run_uts.sh
+++ b/run_uts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -rm -v `pwd`/:/code calico-build bash -c '/tmp/etcd -data-dir=/tmp/default.etcd/ & nosetests calico_containers/tests/unit -c nose.cfg'
+docker run -rm -v `pwd`/calico_containers:/code/calico_containers calico-build bash -c '/tmp/etcd -data-dir=/tmp/default.etcd/ & nosetests calico_containers/tests/unit -c nose.cfg'


### PR DESCRIPTION
Fixes up python path issues so you can run calicoctl.py from ./calico_containers/ and still build correctly.