### PR TITLE
Fixes #150, degrades fatal system dep errors to warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Usage:
   calicoctl container remove <CONTAINER> [--force]
   calicoctl reset
   calicoctl diags
+  calicoctl checksystem [--fix]
   calicoctl restart-docker-with-alternative-unix-socket
   calicoctl restart-docker-without-alternative-unix-socket
 

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -282,14 +282,12 @@ def node(ip, node_image, ip6=""):
     enforce_root()
 
     if not module_loaded("ip6_tables"):
-        print >> sys.stderr, "module ip6_tables isn't loaded. Load with " \
+        print >> sys.stderr, "WARNING: calico was unable to detect the ip6_tables module. Load with " \
                              "`modprobe ip6_tables`"
-        sys.exit(2)
 
     if not module_loaded("xt_set"):
-        print >> sys.stderr, "module xt_set isn't loaded. Load with " \
+        print >> sys.stderr, "WARNING: calico was unable to detect the xt_set module. Load with " \
                              "`modprobe xt_set`"
-        sys.exit(2)
 
     # Set up etcd
     ipv4_pools = client.get_ip_pools("v4")
@@ -306,8 +304,12 @@ def node(ip, node_image, ip6=""):
 
     # Enable IP forwarding since all compute hosts are vRouters.
     # IPv4 forwarding should be enabled already by docker.
-    sysctl("-w", "net.ipv4.ip_forward=1")
-    sysctl("-w", "net.ipv6.conf.all.forwarding=1")
+
+    if "1" not in sysctl("net.ipv4.ip_forward"):
+        print >> sys.stderr, "WARNING: ipv4 forwarding is not enabled."
+
+    if "1" not in sysctl("net.ipv6.conf.all.forwarding"):
+        print >> sys.stderr, "WARNING: ipv6 forwarding is not enabled."
 
     if docker_restarter.is_using_alternative_socket():
         # At this point, docker is listening on a new port but powerstrip

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -382,13 +382,15 @@ def checksystem(fix=False, quit_if_error=False):
     :return: True if all system dependencies are in the proper state, False if they are not, and exit with status 1
              if the fix flag was passed in and they could not be fixed
     """
-    if fix:
-        # modprobe and sysctl require root privileges to make modifications.
-        enforce_root()
+    enforce_root()
 
-    modprobe = sh.Command._create('modprobe')
+
     system_ok = True
-    if not module_loaded("ip6_tables"):
+    modprobe = sh.Command._create('modprobe')
+    ip6tables = sh.Command._create('ip6tables')
+    try:
+        ip6tables("-L")
+    except:
         if fix:
             try:
                 modprobe('ip6_tables')

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -376,11 +376,14 @@ def node(ip, node_image, ip6=""):
 
 def checksystem(fix=False, quit_if_error=False):
     """
-    Checks that the system is setup correctly. If --fix is passed in at command line, this command
-    will attempt to fix any issues it encounters. If any fixes fail, it will exit(1)
+    Checks that the system is setup correctly. fix==True, this command
+    will attempt to fix any issues it encounters. If any fixes fail, it will exit(1). Fix will automatically
+    be set to True if the user specifies --fix at the command line.
 
-    :return: True if all system dependencies are in the proper state, False if they are not, and exit with status 1
-             if the fix flag was passed in and they could not be fixed
+    :param fix: if True, try to fix any system dependency issues that are detected.
+    :param quit_if_error: if True, quit with error code 1 if any issues are detected, or if any fixes are unsuccesful.
+    :return: True if all system dependencies are in the proper state, False if they are not. This function
+             will sys.exit(1) instead of returning false if quit_if_error == True
     """
     enforce_root()
 
@@ -395,7 +398,7 @@ def checksystem(fix=False, quit_if_error=False):
             try:
                 modprobe('ip6_tables')
             except:
-                print >> sys.stderr, "ERROR: calico could not enable ip6_tables."
+                print >> sys.stderr, "ERROR: Could not enable ip6_tables."
                 system_ok = False
         else:
             print >> sys.stderr, "WARNING: calico was unable to detect the ip6_tables module. Load with " \
@@ -407,7 +410,7 @@ def checksystem(fix=False, quit_if_error=False):
             try:
                 modprobe('xt_set')
             except:
-                print >> sys.stderr, "ERROR: calico could not enable xt_set."
+                print >> sys.stderr, "ERROR: Could not enable xt_set."
                 system_ok = False
         else:
             print >> sys.stderr, "WARNING: calico was unable to detect the xt_set module. Load with " \
@@ -419,7 +422,7 @@ def checksystem(fix=False, quit_if_error=False):
     if "1" not in sysctl("net.ipv4.ip_forward"):
         if fix:
             if "1" not in sysctl("-w", "net.ipv4.ip_forward=1"):
-                print >> sys.stderr, "ERROR: calico could not enable ipv4 forwarding."
+                print >> sys.stderr, "ERROR: Could not enable ipv4 forwarding."
                 system_ok = False
         else:
             print >> sys.stderr, "WARNING: ipv4 forwarding is not enabled."
@@ -428,7 +431,7 @@ def checksystem(fix=False, quit_if_error=False):
     if "1" not in sysctl("net.ipv6.conf.all.forwarding"):
         if fix:
             if "1" not in sysctl("-w", "net.ipv6.conf.all.forwarding=1"):
-                print >> sys.stderr, "ERROR: calico could not enable ipv6 forwarding."
+                print >> sys.stderr, "ERROR: Could not enable ipv6 forwarding."
                 system_ok = False
         else:
             print >> sys.stderr, "WARNING: ipv6 forwarding is not enabled."

--- a/calico_containers/tests/st/docker_host.py
+++ b/calico_containers/tests/st/docker_host.py
@@ -18,6 +18,9 @@ class DockerHost(object):
         pwd = sh.pwd().stdout.rstrip()
         docker.run("--privileged", "-v", pwd+":/code", "--name", self.name, "-tid", "jpetazzo/dind")
 
+        # Since `calicoctl node` doesn't fix ipv6 forwarding and module loading, we must manually fix it
+        self.calicoctl("checksystem --fix")
+
         self.ip = docker.inspect("--format", "{{ .NetworkSettings.IPAddress }}",
                                  self.name).stdout.rstrip()
 


### PR DESCRIPTION
Fixes #150, calicoctl now only prints *warnings* for detected issues concerning system dependencies during node creation, but will not cancel the process if it detects them. 

For now, if our system check incorrectly detects issues, the user will just have to read past those warnings knowing that their system is in fact OK. We will have to work towards better detection across host platforms in the future so users won't be bothered with any incorrect messages (see #150).

Additionally, added the `calicoctl checksystem [--fix]` command which will print any detected issues, and will attempt to fix them if the `--fix` flag is provided.