### PR TITLE
Remove device routes from BIRD kernel config.

### DIFF
--- a/node_filesystem/templates/bird.cfg.template
+++ b/node_filesystem/templates/bird.cfg.template
@@ -17,7 +17,6 @@ protocol kernel {
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
   import all;
-  device routes;
   export all;        # Default is export none
   graceful restart;  # Turn on graceful restart to reduce potential flaps in
                      # routes when reloading BIRD configuration.  With a full

--- a/node_filesystem/templates/bird6.cfg.template
+++ b/node_filesystem/templates/bird6.cfg.template
@@ -17,7 +17,6 @@ protocol kernel {
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
   import all;
-  device routes;
   export all;        # Default is export none
   graceful restart;  # Turn on graceful restart to reduce potential flaps in
                      # routes when reloading BIRD configuration.  With a full


### PR DESCRIPTION
The device routes switch tells BIRD to export device routes to the kernel.  This isn't required as the underlying network configuration has already set up device routes within the kernel leading to "File Exists" spam in the BIRD log.