### PR TITLE
Stop setting the endpoint name since we can't know it.

### DIFF
--- a/calico_containers/docker_plugin.py
+++ b/calico_containers/docker_plugin.py
@@ -68,15 +68,11 @@ def create_endpoint():
     ep_id = json_data["EndpointID"]
     net_id = json_data["NetworkID"]
 
-    # TODO - Endpoint is broken. We don't know the interface name (libnetwork
-    # decides it) so it shouldn't be a mandatory parameter.
-
     # Create a calico endpoint object which we can populate and return to
     # libnetwork at the end of this method.
     ep = Endpoint(ep_id=ep_id,
                   state="active",
-                  mac=FIXED_MAC,
-                  if_name='cali0')
+                  mac=FIXED_MAC)
     ep.profile_id = net_id
 
     # This method is split into three phases that have side effects.

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -178,7 +178,7 @@ class Rules(namedtuple("Rules", ["id", "inbound_rules", "outbound_rules"])):
 
 class Endpoint(object):
 
-    def __init__(self, ep_id, state, mac, if_name):
+    def __init__(self, ep_id, state, mac, if_name=None):
         self.ep_id = ep_id
         self.state = state
         self.mac = mac
@@ -218,7 +218,7 @@ class Endpoint(object):
         ep = cls(ep_id=ep_id,
                  state=json_dict["state"],
                  mac=json_dict["mac"],
-                 if_name= if_name)
+                 if_name=if_name)
         for net in json_dict["ipv4_nets"]:
             ep.ipv4_nets.add(IPNetwork(net))
         for net in json_dict["ipv6_nets"]:


### PR DESCRIPTION
Make the endpoint an optional thing, defaulted to None.

Endpoint is broken. We don't know the interface name (libnetwork
decides it) so it shouldn't be a mandatory parameter.

