### PR TITLE
cd to dist directory before running docopt-completion

### DIFF
--- a/create_binary.sh
+++ b/create_binary.sh
@@ -27,7 +27,7 @@ docker rm -f docopt || true
 # `user` account in the container to write to it.
 docker run -v `pwd`/calico_containers:/code/calico_containers \
  -v `pwd`/dist:/code/dist --name docopt calico-build \
- docopt-completion --manual-bash dist/calicoctl
+ /bin/sh -c 'cd dist; docopt-completion --manual-bash ./calicoctl'
 docker rm -f docopt || true
 
 echo "Build output is in dist/"

--- a/create_binary.sh
+++ b/create_binary.sh
@@ -25,9 +25,9 @@ docker rm -f docopt || true
 # mount calico_containers and dist under /code work directory.  Don't use /code
 # as the mountpoint directly since the host permissions may not allow the
 # `user` account in the container to write to it.
-docker run -v `pwd`/calico_containers:/code/calico_containers \
+docker run -w /code/dist -v `pwd`/calico_containers:/code/calico_containers \
  -v `pwd`/dist:/code/dist --name docopt calico-build \
- /bin/sh -c 'cd dist; docopt-completion --manual-bash ./calicoctl'
+ docopt-completion --manual-bash ./calicoctl
 docker rm -f docopt || true
 
 echo "Build output is in dist/"


### PR DESCRIPTION
docopt-completion writes file to pwd, so cd before running command so output is in the dist directory.