### PR TITLE
Fix test_ipv6.py ST

### DIFF
--- a/calico_containers/tests/st/docker_host.py
+++ b/calico_containers/tests/st/docker_host.py
@@ -28,7 +28,7 @@ class DockerHost(object):
             ip6 = docker.inspect("--format", "{{ .NetworkSettings.GlobalIPv6Address }}",
                                  self.name).stdout.rstrip()
             # TODO: change this hardcoding when we set up IPv6 for hosts
-            self.ip6 = ip6 or "fd80:24e2:f998:72d6::1"
+            self.ip6 = ip6 or "fd80:24e2:f998:abcd::1"
 
             # Make sure docker is up
             docker_ps = partial(self.execute, "docker ps")

--- a/calico_containers/tests/st/test_ipv6.py
+++ b/calico_containers/tests/st/test_ipv6.py
@@ -12,6 +12,10 @@ class TestIpv6(TestBase):
         """
         Test mainline functionality with IPv6 addresses.
         """
+        # Use a UUID for net name so that independent runs of the test use
+        # different names.  This helps in the case where etcd gets restarted
+        # but Docker does not, since libnetwork will only create the network
+        # if it doesn't exist.
         net_name = uuid.uuid4()
         host = DockerHost('host', start_calico=False)
         host.start_calico_node(ip=host.ip, ip6=host.ip6)

--- a/calico_containers/tests/st/test_ipv6.py
+++ b/calico_containers/tests/st/test_ipv6.py
@@ -1,5 +1,6 @@
 from subprocess import CalledProcessError
 from functools import partial
+import uuid
 
 from test_base import TestBase
 from docker_host import DockerHost
@@ -11,19 +12,15 @@ class TestIpv6(TestBase):
         """
         Test mainline functionality with IPv6 addresses.
         """
+        net_name = uuid.uuid4()
         host = DockerHost('host', start_calico=False)
         host.start_calico_node(ip=host.ip, ip6=host.ip6)
         host.assert_driver_up()
 
-        host.execute("docker run --net=calico:test"
-                     " -tid --name=node1 phusion/baseimage:0.9.16")
-        host.execute("docker run --net=calico:test"
-                     " -tid --name=node2 phusion/baseimage:0.9.16")
-
-        # Configure the nodes with the same profiles.
-        host.calicoctl("profile add TEST_GROUP")
-        host.calicoctl("profile TEST_GROUP member add node1")
-        host.calicoctl("profile TEST_GROUP member add node2")
+        host.execute("docker run --net=calico:%s"
+                     " -tid --name=node1 phusion/baseimage:0.9.16" % net_name)
+        host.execute("docker run --net=calico:%s"
+                     " -tid --name=node2 phusion/baseimage:0.9.16" % net_name)
 
         # Perform a docker inspect to extract the configured IP addresses.
         node1_ip = host.execute("docker inspect --format "


### PR DESCRIPTION
In order to get this working, I changed the hardcoded IPv6 address for the
DockerHost to be in a range separate to the container pool.  Otherwise, the
first container would get an IP that conflicted with its own gateway.