### PR TITLE
Make DockerHost context manager that cleans up.

### DIFF
--- a/calico_containers/tests/st/test_add_container.py
+++ b/calico_containers/tests/st/test_add_container.py
@@ -11,16 +11,18 @@ class TestAddContainer(TestBase):
         """
         Test adding container to calico networking after it exists.
         """
-        host = DockerHost('host')
+        with DockerHost('host') as host:
 
-        host.execute("docker run -tid --name=node busybox")
-        host.calicoctl("profile add TEST_GROUP")
+            host.execute("docker run -tid --name=node busybox")
+            host.calicoctl("profile add TEST_GROUP")
 
-        # Use the `container add` command instead of passing a CALICO_IP on
-        # container creation. Note this no longer needs DOCKER_HOST specified.
-        host.calicoctl("container add node 192.168.1.1")
-        host.calicoctl("profile TEST_GROUP member add node")
+            # Use the `container add` command instead of passing a CALICO_IP on
+            # container creation. Note this no longer needs DOCKER_HOST
+            # specified.
+            host.calicoctl("container add node 192.168.1.1")
+            host.calicoctl("profile TEST_GROUP member add node")
 
-        # Wait for felix to program down the route.
-        check_route = partial(host.execute, "ip route | grep '192\.168\.1\.1'")
-        retry_until_success(check_route, ex_class=CalledProcessError)
+            # Wait for felix to program down the route.
+            check_route = partial(host.execute,
+                                  "ip route | grep '192\.168\.1\.1'")
+            retry_until_success(check_route, ex_class=CalledProcessError)

--- a/calico_containers/tests/st/test_add_ip.py
+++ b/calico_containers/tests/st/test_add_ip.py
@@ -12,74 +12,76 @@ class TestAddIp(TestBase):
         """
         Test adding multiple IPs per workload.
         """
-        host = DockerHost('host')
+        with DockerHost('host') as host:
 
-        # TODO get this test working with libnetwork.  Right now we don't have
-        # any way to assign multiple IPs with libnetwork, nor can we use
-        # calicoctl commands to manipulate libnetwork-based containers or
-        # profiles since these names are not presented to the driver.
-        # host.execute("docker run --net=calico:test -tid --name=node1 busybox")
-        # ip11 = host.execute("docker inspect --format "
-        #                     "'{{ .NetworkSettings.IPAddress }}' "
-        #                     "node1").rstrip()
-        ip11 = "192.168.1.1"
-        host.execute("docker run -tid --name=node1 --net=none busybox")
-        host.calicoctl("container add node1 %s" % ip11)
+            # TODO get this test working with libnetwork.  Right now we don't
+            # have any way to assign multiple IPs with libnetwork, nor can we
+            # use calicoctl commands to manipulate libnetwork-based containers
+            # or profiles since these names are not presented to the driver.
+            # host.execute("docker run --net=calico:test -tid"
+            #              " --name=node1 busybox")
+            # ip11 = host.execute("docker inspect --format "
+            #                     "'{{ .NetworkSettings.IPAddress }}' "
+            #                     "node1").rstrip()
+            ip11 = "192.168.1.1"
+            host.execute("docker run -tid --name=node1 --net=none busybox")
+            host.calicoctl("container add node1 %s" % ip11)
 
-        ip21 = "192.168.1.2"
-        host.execute("docker run -tid --name=node2 busybox")
-        host.calicoctl("container add node2 %s --interface=hello" % ip21)
+            ip21 = "192.168.1.2"
+            host.execute("docker run -tid --name=node2 busybox")
+            host.calicoctl("container add node2 %s --interface=hello" % ip21)
 
-        host.calicoctl("profile add TEST_GROUP")
-        host.calicoctl("profile TEST_GROUP member add node1")
-        host.calicoctl("profile TEST_GROUP member add node2")
+            host.calicoctl("profile add TEST_GROUP")
+            host.calicoctl("profile TEST_GROUP member add node1")
+            host.calicoctl("profile TEST_GROUP member add node2")
 
-        test_ping = partial(host.execute,
-                            "docker exec node1 ping %s -c 1 -W 1" % ip21)
-        retry_until_success(test_ping, ex_class=CalledProcessError)
+            test_ping = partial(host.execute,
+                                "docker exec node1 ping %s -c 1 -W 1" % ip21)
+            retry_until_success(test_ping, ex_class=CalledProcessError)
 
-        # Add two more addresses to node1 and one more to node2
-        ip12 = "192.168.2.1"
-        ip13 = "192.168.3.1"
-        host.calicoctl("container node1 ip add %s" % ip12)
-        host.calicoctl("container node1 ip add %s" % ip13)
+            # Add two more addresses to node1 and one more to node2
+            ip12 = "192.168.2.1"
+            ip13 = "192.168.3.1"
+            host.calicoctl("container node1 ip add %s" % ip12)
+            host.calicoctl("container node1 ip add %s" % ip13)
 
-        ip22 = "192.168.2.2"
-        host.calicoctl("container node2 ip add %s --interface=hello" % ip22)
+            ip22 = "192.168.2.2"
+            host.calicoctl("container node2 ip add %s --interface=hello" %
+                           ip22)
 
-        host.execute("docker exec node1 ping %s -c 1" % ip22)
-        host.execute("docker exec node2 ping %s -c 1" % ip11)
-        host.execute("docker exec node2 ping %s -c 1" % ip12)
-        host.execute("docker exec node2 ping %s -c 1" % ip13)
+            host.execute("docker exec node1 ping %s -c 1" % ip22)
+            host.execute("docker exec node2 ping %s -c 1" % ip11)
+            host.execute("docker exec node2 ping %s -c 1" % ip12)
+            host.execute("docker exec node2 ping %s -c 1" % ip13)
 
-        # Now stop and restart node 1 and node 2.
-        host.execute("docker stop node1")
-        host.execute("docker stop node2")
-        host.execute("docker start node1")
-        host.execute("docker start node2")
+            # Now stop and restart node 1 and node 2.
+            host.execute("docker stop node1")
+            host.execute("docker stop node2")
+            host.execute("docker start node1")
+            host.execute("docker start node2")
 
-        retry_until_success(test_ping, ex_class=CalledProcessError)
+            retry_until_success(test_ping, ex_class=CalledProcessError)
 
-        # Test pings between the IPs.
-        host.execute("docker exec node1 ping %s -c 1" % ip21)
-        host.execute("docker exec node1 ping %s -c 1" % ip22)
-        host.execute("docker exec node2 ping %s -c 1" % ip11)
-        host.execute("docker exec node2 ping %s -c 1" % ip12)
-        host.execute("docker exec node2 ping %s -c 1" % ip13)
+            # Test pings between the IPs.
+            host.execute("docker exec node1 ping %s -c 1" % ip21)
+            host.execute("docker exec node1 ping %s -c 1" % ip22)
+            host.execute("docker exec node2 ping %s -c 1" % ip11)
+            host.execute("docker exec node2 ping %s -c 1" % ip12)
+            host.execute("docker exec node2 ping %s -c 1" % ip13)
 
-        # Now remove and check pings to the removed addresses no longer work.
-        # host.calicoctl("container node1 ip remove %s" % ip12)
-        host.calicoctl("container node2 ip remove %s "
-                       "--interface=hello" % ip22)
-        host.execute("docker exec node1 ping %s -c 1" % ip21)
-        host.execute("docker exec node2 ping %s -c 1" % ip11)
-        with self.assertRaises(CalledProcessError):
-            host.execute("docker exec node1 ping %s -c 1 -W 1" % ip22)
-        with self.assertRaises(CalledProcessError):
-            host.execute("docker exec node2 ping %s -c 1 -W 1" % ip12)
-        host.execute("docker exec node2 ping %s -c 1" % ip13)
-
-        # Check that we can't remove addresses twice
-        with self.assertRaises(CalledProcessError):
+            # Now remove and check can't ping the removed addresses.
+            # host.calicoctl("container node1 ip remove %s" % ip12)
             host.calicoctl("container node2 ip remove %s "
                            "--interface=hello" % ip22)
+            host.execute("docker exec node1 ping %s -c 1" % ip21)
+            host.execute("docker exec node2 ping %s -c 1" % ip11)
+            with self.assertRaises(CalledProcessError):
+                host.execute("docker exec node1 ping %s -c 1 -W 1" % ip22)
+            with self.assertRaises(CalledProcessError):
+                host.execute("docker exec node2 ping %s -c 1 -W 1" % ip12)
+            host.execute("docker exec node2 ping %s -c 1" % ip13)
+
+            # Check that we can't remove addresses twice
+            with self.assertRaises(CalledProcessError):
+                host.calicoctl("container node2 ip remove %s "
+                               "--interface=hello" % ip22)

--- a/calico_containers/tests/st/test_arg_parsing.py
+++ b/calico_containers/tests/st/test_arg_parsing.py
@@ -9,62 +9,81 @@ class TestArgParsing(TestBase):
         """
         Test that calicoctl correctly accepts or rejects given argument.
         """
-        host = DockerHost('host', start_calico=False)
+        with DockerHost('host', start_calico=False) as host:
 
-        # Run various commands with invalid IPs.
-        cases = [("node --ip=127.a.0.1", 1),
-                 ("node --ip=aa:bb::cc", 1),
-                 ("node --ip=127.0.0.1 --ip6=127.0.0.1", 1),
-                 ("node --ip=127.0.0.1 --ip6=aa:bb::zz", 1),
-                 ("bgppeer rr add 127.a.0.1", 1),
-                 ("bgppeer rr add aa:bb::zz", 1),
-                 ("pool add 127.a.0.1", 1),
-                 ("pool add aa:bb::zz", 1),
-                 ("container node1 ip add 127.a.0.1", 1),
-                 ("container node1 ip add aa:bb::zz", 1),
-                 ("container add node1 127.a.0.1", 1),
-                 ("container add node1 aa:bb::zz", 1)]
-        for cmd, rc in cases:
-            with self.assertRaises(CalledProcessError) as cm:
-                host.calicoctl(cmd)
-            self.assertEqual(cm.exception.returncode, rc,
-                             "calicoctl %s returned code %s "
-                             "but we expected %s" % (cmd,
-                                                     cm.exception.returncode,
-                                                     rc))
+            # Run various commands with invalid IPs.
+            cases = [("node --ip=127.a.0.1", 1),
+                     ("node --ip=aa:bb::cc", 1),
+                     ("node --ip=127.0.0.1 --ip6=127.0.0.1", 1),
+                     ("node --ip=127.0.0.1 --ip6=aa:bb::zz", 1),
+                     ("bgppeer rr add 127.a.0.1", 1),
+                     ("bgppeer rr add aa:bb::zz", 1),
+                     ("pool add 127.a.0.1", 1),
+                     ("pool add aa:bb::zz", 1),
+                     ("container node1 ip add 127.a.0.1", 1),
+                     ("container node1 ip add aa:bb::zz", 1),
+                     ("container add node1 127.a.0.1", 1),
+                     ("container add node1 aa:bb::zz", 1)]
+            for cmd, rc in cases:
+                with self.assertRaises(CalledProcessError) as cm:
+                    host.calicoctl(cmd)
+                self.assertEqual(cm.exception.returncode, rc,
+                                 "calicoctl %s returned code %s "
+                                 "but we expected %s" %
+                                 (cmd, cm.exception.returncode, rc))
 
-        # Add some pools and BGP peers and check the show commands"
-        host.calicoctl("bgppeer rr add 1.2.3.4")
-        self.assertIn("1.2.3.4", host.calicoctl("bgppeer rr show").rstrip())
-        self.assertIn("1.2.3.4", host.calicoctl("bgppeer rr show --ipv4").rstrip())
-        self.assertNotIn("1.2.3.4", host.calicoctl("bgppeer rr show --ipv6").rstrip())
-        host.calicoctl("bgppeer rr remove 1.2.3.4")
-        self.assertNotIn("1.2.3.4", host.calicoctl("bgppeer rr show").rstrip())
+            # Add some pools and BGP peers and check the show commands"
+            host.calicoctl("bgppeer rr add 1.2.3.4")
+            self.assertIn("1.2.3.4",
+                          host.calicoctl("bgppeer rr show").rstrip())
+            self.assertIn("1.2.3.4",
+                          host.calicoctl("bgppeer rr show --ipv4").rstrip())
+            self.assertNotIn("1.2.3.4",
+                             host.calicoctl("bgppeer rr show --ipv6").rstrip())
+            host.calicoctl("bgppeer rr remove 1.2.3.4")
+            self.assertNotIn("1.2.3.4",
+                             host.calicoctl("bgppeer rr show").rstrip())
 
-        host.calicoctl("bgppeer rr add aa:bb::ff")
-        self.assertIn("aa:bb::ff", host.calicoctl("bgppeer rr show").rstrip())
-        self.assertNotIn("aa:bb::ff", host.calicoctl("bgppeer rr show --ipv4").rstrip())
-        self.assertIn("aa:bb::ff", host.calicoctl("bgppeer rr show --ipv6").rstrip())
-        host.calicoctl("bgppeer rr remove aa:bb::ff")
-        self.assertNotIn("aa:bb::ff", host.calicoctl("bgppeer rr show").rstrip())
+            host.calicoctl("bgppeer rr add aa:bb::ff")
+            self.assertIn("aa:bb::ff",
+                          host.calicoctl("bgppeer rr show").rstrip())
+            self.assertNotIn("aa:bb::ff",
+                             host.calicoctl("bgppeer rr show --ipv4").rstrip())
+            self.assertIn("aa:bb::ff",
+                          host.calicoctl("bgppeer rr show --ipv6").rstrip())
+            host.calicoctl("bgppeer rr remove aa:bb::ff")
+            self.assertNotIn("aa:bb::ff",
+                             host.calicoctl("bgppeer rr show").rstrip())
 
-        host.calicoctl("pool add 1.2.3.4")
-        self.assertIn("1.2.3.4/32", host.calicoctl("pool show").rstrip())
-        self.assertIn("1.2.3.4/32", host.calicoctl("pool show --ipv4").rstrip())
-        self.assertNotIn("1.2.3.4/32", host.calicoctl("pool show --ipv6").rstrip())
-        host.calicoctl("pool remove 1.2.3.4")
-        self.assertNotIn("1.2.3.4/32", host.calicoctl("pool show").rstrip())
+            host.calicoctl("pool add 1.2.3.4")
+            self.assertIn("1.2.3.4/32",
+                          host.calicoctl("pool show").rstrip())
+            self.assertIn("1.2.3.4/32",
+                          host.calicoctl("pool show --ipv4").rstrip())
+            self.assertNotIn("1.2.3.4/32",
+                             host.calicoctl("pool show --ipv6").rstrip())
+            host.calicoctl("pool remove 1.2.3.4")
+            self.assertNotIn("1.2.3.4/32",
+                             host.calicoctl("pool show").rstrip())
 
-        host.calicoctl("pool add 1.2.3.0/24")
-        self.assertIn("1.2.3.0/24", host.calicoctl("pool show").rstrip())
-        self.assertIn("1.2.3.0/24", host.calicoctl("pool show --ipv4").rstrip())
-        self.assertNotIn("1.2.3.0/24", host.calicoctl("pool show --ipv6").rstrip())
-        host.calicoctl("pool remove 1.2.3.0/24")
-        self.assertNotIn("1.2.3.0/24", host.calicoctl("pool show").rstrip())
+            host.calicoctl("pool add 1.2.3.0/24")
+            self.assertIn("1.2.3.0/24",
+                          host.calicoctl("pool show").rstrip())
+            self.assertIn("1.2.3.0/24",
+                          host.calicoctl("pool show --ipv4").rstrip())
+            self.assertNotIn("1.2.3.0/24",
+                             host.calicoctl("pool show --ipv6").rstrip())
+            host.calicoctl("pool remove 1.2.3.0/24")
+            self.assertNotIn("1.2.3.0/24",
+                             host.calicoctl("pool show").rstrip())
 
-        host.calicoctl("pool add aa:bb::ff")
-        self.assertIn("aa:bb::ff/128", host.calicoctl("pool show").rstrip())
-        self.assertNotIn("aa:bb::ff/128", host.calicoctl("pool show --ipv4").rstrip())
-        self.assertIn("aa:bb::ff/128", host.calicoctl("pool show --ipv6").rstrip())
-        host.calicoctl("pool remove aa:bb::ff/128")
-        self.assertNotIn("aa:bb::ff/128", host.calicoctl("pool show").rstrip())
+            host.calicoctl("pool add aa:bb::ff")
+            self.assertIn("aa:bb::ff/128",
+                          host.calicoctl("pool show").rstrip())
+            self.assertNotIn("aa:bb::ff/128",
+                             host.calicoctl("pool show --ipv4").rstrip())
+            self.assertIn("aa:bb::ff/128",
+                          host.calicoctl("pool show --ipv6").rstrip())
+            host.calicoctl("pool remove aa:bb::ff/128")
+            self.assertNotIn("aa:bb::ff/128",
+                             host.calicoctl("pool show").rstrip())

--- a/calico_containers/tests/st/test_base.py
+++ b/calico_containers/tests/st/test_base.py
@@ -2,7 +2,7 @@ import requests
 from sh import docker
 from unittest import TestCase
 
-from utils import get_ip, delete_container
+from utils import get_ip
 
 
 class TestBase(TestCase):

--- a/calico_containers/tests/st/test_diags.py
+++ b/calico_containers/tests/st/test_diags.py
@@ -7,6 +7,6 @@ class TestDiags(TestBase):
         """
         Test that the diags command successfully uploads the diags file.
         """
-        host = DockerHost('host', start_calico=False)
-        link = host.calicoctl("diags")
-        self.assertIn("https://transfer.sh/", link)
+        with DockerHost('host', start_calico=False) as host:
+            link = host.calicoctl("diags")
+            self.assertIn("https://transfer.sh/", link)

--- a/calico_containers/tests/st/test_duplicate_ips.py
+++ b/calico_containers/tests/st/test_duplicate_ips.py
@@ -15,44 +15,50 @@ class TestDuplicateIps(TestBase):
         Start two workloads with the same IP on different hosts. Make sure they
         can be reached from all places even after one of them is deleted.
         """
-        host1 = DockerHost('host1')
-        host2 = DockerHost('host2')
-        host3 = DockerHost('host3')
+        with DockerHost('host1') as host1, \
+             DockerHost('host2') as host2, \
+             DockerHost('host3') as host3:
 
-        # Set up three workloads on three hosts
-        host1.execute("docker run -e CALICO_IP=192.168.1.1 --name workload1 -tid busybox")
-        host2.execute("docker run -e CALICO_IP=192.168.1.2 --name workload2 -tid busybox")
-        host3.execute("docker run -e CALICO_IP=192.168.1.3 --name workload3 -tid busybox")
+            # Set up three workloads on three hosts
+            host1.execute("docker run -e CALICO_IP=192.168.1.1 "
+                          "--name workload1 -tid busybox")
+            host2.execute("docker run -e CALICO_IP=192.168.1.2 "
+                          "--name workload2 -tid busybox")
+            host3.execute("docker run -e CALICO_IP=192.168.1.3 "
+                          "--name workload3 -tid busybox")
 
-        # Set up the workloads with duplicate IPs
-        host1.execute("docker run -e CALICO_IP=192.168.1.4 --name dup1 -tid busybox")
-        host2.execute("docker run -e CALICO_IP=192.168.1.4 --name dup2 -tid busybox")
+            # Set up the workloads with duplicate IPs
+            host1.execute("docker run -e CALICO_IP=192.168.1.4 "
+                          "--name dup1 -tid busybox")
+            host2.execute("docker run -e CALICO_IP=192.168.1.4 "
+                          "--name dup2 -tid busybox")
 
-        host1.calicoctl("profile add TEST_PROFILE")
+            host1.calicoctl("profile add TEST_PROFILE")
 
-        # Add everyone to the same profile
-        host1.calicoctl("profile TEST_PROFILE member add workload1")
-        host1.calicoctl("profile TEST_PROFILE member add dup1")
-        host2.calicoctl("profile TEST_PROFILE member add workload2")
-        host2.calicoctl("profile TEST_PROFILE member add dup2")
-        host3.calicoctl("profile TEST_PROFILE member add workload3")
+            # Add everyone to the same profile
+            host1.calicoctl("profile TEST_PROFILE member add workload1")
+            host1.calicoctl("profile TEST_PROFILE member add dup1")
+            host2.calicoctl("profile TEST_PROFILE member add workload2")
+            host2.calicoctl("profile TEST_PROFILE member add dup2")
+            host3.calicoctl("profile TEST_PROFILE member add workload3")
 
-        # Wait for the workload networking to converge.
-        ping = partial(host1.execute, "docker exec workload1 ping -c 4 192.168.1.4")
-        retry_until_success(ping, ex_class=CalledProcessError)
+            # Wait for the workload networking to converge.
+            ping = partial(host1.execute,
+                           "docker exec workload1 ping -c 4 192.168.1.4")
+            retry_until_success(ping, ex_class=CalledProcessError)
 
-        # Check for standard connectivity
-        host1.execute("docker exec workload1 ping -c 4 192.168.1.4")
-        host2.execute("docker exec workload2 ping -c 4 192.168.1.4")
-        host3.execute("docker exec workload3 ping -c 4 192.168.1.4")
+            # Check for standard connectivity
+            host1.execute("docker exec workload1 ping -c 4 192.168.1.4")
+            host2.execute("docker exec workload2 ping -c 4 192.168.1.4")
+            host3.execute("docker exec workload3 ping -c 4 192.168.1.4")
 
-        # Delete one of the duplciates.
-        host2.execute("docker rm -f dup2")
+            # Delete one of the duplciates.
+            host2.execute("docker rm -f dup2")
 
-        # Wait for the workload networking to converge.
-        retry_until_success(ping, ex_class=CalledProcessError)
+            # Wait for the workload networking to converge.
+            retry_until_success(ping, ex_class=CalledProcessError)
 
-        # Check standard connectivity still works.
-        host1.execute("docker exec workload1 ping -c 4 192.168.1.4")
-        host2.execute("docker exec workload2 ping -c 4 192.168.1.4")
-        host3.execute("docker exec workload3 ping -c 4 192.168.1.4")
+            # Check standard connectivity still works.
+            host1.execute("docker exec workload1 ping -c 4 192.168.1.4")
+            host2.execute("docker exec workload2 ping -c 4 192.168.1.4")
+            host3.execute("docker exec workload3 ping -c 4 192.168.1.4")

--- a/calico_containers/tests/st/test_ipv6.py
+++ b/calico_containers/tests/st/test_ipv6.py
@@ -17,30 +17,34 @@ class TestIpv6(TestBase):
         # but Docker does not, since libnetwork will only create the network
         # if it doesn't exist.
         net_name = uuid.uuid4()
-        host = DockerHost('host', start_calico=False)
-        host.start_calico_node(ip=host.ip, ip6=host.ip6)
-        host.assert_driver_up()
+        with DockerHost('host', start_calico=False) as host:
+            host.start_calico_node(ip=host.ip, ip6=host.ip6)
+            host.assert_driver_up()
 
-        host.execute("docker run --net=calico:%s"
-                     " -tid --name=node1 phusion/baseimage:0.9.16" % net_name)
-        host.execute("docker run --net=calico:%s"
-                     " -tid --name=node2 phusion/baseimage:0.9.16" % net_name)
+            host.execute("docker run --net=calico:%s"
+                         " -tid --name=node1 phusion/baseimage:0.9.16" %
+                         net_name)
+            host.execute("docker run --net=calico:%s"
+                         " -tid --name=node2 phusion/baseimage:0.9.16" %
+                         net_name)
 
-        # Perform a docker inspect to extract the configured IP addresses.
-        node1_ip = host.execute("docker inspect --format "
-                                "'{{ .NetworkSettings.GlobalIPv6Address }}' "
-                                "node1").rstrip()
-        node2_ip = host.execute("docker inspect --format "
-                                "'{{ .NetworkSettings.GlobalIPv6Address }}' "
-                                "node2").rstrip()
+            # Perform a docker inspect to extract the configured IP addresses.
+            node1_ip = host.execute("docker inspect --format "
+                                    "'{{ .NetworkSettings."
+                                    "GlobalIPv6Address }}' "
+                                    "node1").rstrip()
+            node2_ip = host.execute("docker inspect --format "
+                                    "'{{ .NetworkSettings."
+                                    "GlobalIPv6Address }}' "
+                                    "node2").rstrip()
 
-        ping = partial(host.execute,
-                       "docker exec %s ping6 %s -c 1 -W 1" % ("node1",
-                                                              node2_ip))
-        retry_until_success(ping, ex_class=CalledProcessError)
+            ping = partial(host.execute,
+                           "docker exec %s ping6 %s -c 1 -W 1" % ("node1",
+                                                                  node2_ip))
+            retry_until_success(ping, ex_class=CalledProcessError)
 
-        # Check connectivity.
-        host.execute("docker exec %s ping6 %s -c 1" % ("node1", node1_ip))
-        host.execute("docker exec %s ping6 %s -c 1" % ("node1", node2_ip))
-        host.execute("docker exec %s ping6 %s -c 1" % ("node2", node1_ip))
-        host.execute("docker exec %s ping6 %s -c 1" % ("node2", node2_ip))
+            # Check connectivity.
+            host.execute("docker exec %s ping6 %s -c 1" % ("node1", node1_ip))
+            host.execute("docker exec %s ping6 %s -c 1" % ("node1", node2_ip))
+            host.execute("docker exec %s ping6 %s -c 1" % ("node2", node1_ip))
+            host.execute("docker exec %s ping6 %s -c 1" % ("node2", node2_ip))

--- a/calico_containers/tests/st/test_multi_host.py
+++ b/calico_containers/tests/st/test_multi_host.py
@@ -16,41 +16,46 @@ class MultiHostMainline(TestBase):
 
         Almost identical in function to the vagrant coreOS demo.
         """
-        host1 = DockerHost('host1')
-        host2 = DockerHost('host2')
+        with DockerHost('host1') as host1, DockerHost('host2') as host2:
 
-        ip1 = "192.168.1.1"
-        ip2 = "192.168.1.2"
-        ip3 = "192.168.1.3"
-        ip4 = "192.168.1.4"
-        ip5 = "192.168.1.5"
+            ip1 = "192.168.1.1"
+            ip2 = "192.168.1.2"
+            ip3 = "192.168.1.3"
+            ip4 = "192.168.1.4"
+            ip5 = "192.168.1.5"
 
-        host1.execute("docker run -e CALICO_IP=%s --name workload1 -tid busybox" % ip1)
-        host1.execute("docker run -e CALICO_IP=%s --name workload2 -tid busybox" % ip2)
-        host1.execute("docker run -e CALICO_IP=%s --name workload3 -tid busybox" % ip3)
+            host1.execute("docker run -e CALICO_IP=%s "
+                          "--name workload1 -tid busybox" % ip1)
+            host1.execute("docker run -e CALICO_IP=%s "
+                          "--name workload2 -tid busybox" % ip2)
+            host1.execute("docker run -e CALICO_IP=%s "
+                          "--name workload3 -tid busybox" % ip3)
 
-        host2.execute("docker run -e CALICO_IP=%s --name workload4 -tid busybox" % ip4)
-        host2.execute("docker run -e CALICO_IP=%s --name workload5 -tid busybox" % ip5)
+            host2.execute("docker run -e CALICO_IP=%s "
+                          "--name workload4 -tid busybox" % ip4)
+            host2.execute("docker run -e CALICO_IP=%s "
+                          "--name workload5 -tid busybox" % ip5)
 
-        host1.calicoctl("profile add PROF_1_3_5")
-        host1.calicoctl("profile add PROF_2")
-        host1.calicoctl("profile add PROF_4")
+            host1.calicoctl("profile add PROF_1_3_5")
+            host1.calicoctl("profile add PROF_2")
+            host1.calicoctl("profile add PROF_4")
 
-        host1.calicoctl("profile PROF_1_3_5 member add workload1")
-        host1.calicoctl("profile PROF_2 member add workload2")
-        host1.calicoctl("profile PROF_1_3_5 member add workload3")
+            host1.calicoctl("profile PROF_1_3_5 member add workload1")
+            host1.calicoctl("profile PROF_2 member add workload2")
+            host1.calicoctl("profile PROF_1_3_5 member add workload3")
 
-        host2.calicoctl("profile PROF_4 member add workload4")
-        host2.calicoctl("profile PROF_1_3_5 member add workload5")
+            host2.calicoctl("profile PROF_4 member add workload4")
+            host2.calicoctl("profile PROF_1_3_5 member add workload5")
 
-        # Wait for the workload networking to converge.
-        ping = partial(host1.execute, "docker exec workload1 ping -c 4 %s" % ip3)
-        retry_until_success(ping, ex_class=CalledProcessError)
+            # Wait for the workload networking to converge.
+            ping = partial(host1.execute,
+                           "docker exec workload1 ping -c 4 %s" % ip3)
+            retry_until_success(ping, ex_class=CalledProcessError)
 
-        with self.assertRaises(CalledProcessError):
-            host1.execute("docker exec workload1 ping -c 4 %s" % ip2)
+            with self.assertRaises(CalledProcessError):
+                host1.execute("docker exec workload1 ping -c 4 %s" % ip2)
 
-        with self.assertRaises(CalledProcessError):
-            host1.execute("docker exec workload1 ping -c 4 %s" % ip4)
+            with self.assertRaises(CalledProcessError):
+                host1.execute("docker exec workload1 ping -c 4 %s" % ip4)
 
-        host1.execute("docker exec workload1 ping -c 4 %s" % ip5)
+            host1.execute("docker exec workload1 ping -c 4 %s" % ip5)

--- a/calico_containers/tests/st/test_no_net_driver.py
+++ b/calico_containers/tests/st/test_no_net_driver.py
@@ -11,47 +11,47 @@ class TestNoNetDriver(TestBase):
         """
         Test mainline functionality without using the docker network driver.
         """
-        host = DockerHost('host')
+        with DockerHost('host') as host:
 
-        host.calicoctl("profile add TEST_GROUP")
+            host.calicoctl("profile add TEST_GROUP")
 
-        # Remove the environment variable such that docker run does not utilize
-        # the docker network driver.
-        host.execute("docker run -tid --name=node1 busybox")
-        host.execute("docker run -tid --name=node2 busybox")
+            # Remove the environment variable such that docker run does not
+            # utilize the docker network driver.
+            host.execute("docker run -tid --name=node1 busybox")
+            host.execute("docker run -tid --name=node2 busybox")
 
-        # Attempt to configure the nodes with the same profiles.  This will
-        # fail since we didn't use the driver to create the nodes.
-        with self.assertRaises(CalledProcessError):
+            # Attempt to configure the nodes with the same profiles.  This will
+            # fail since we didn't use the driver to create the nodes.
+            with self.assertRaises(CalledProcessError):
+                host.calicoctl("profile TEST_GROUP member add node1")
+            with self.assertRaises(CalledProcessError):
+                host.calicoctl("profile TEST_GROUP member add node2")
+
+            # Add the nodes to Calico networking.
+            host.calicoctl("container add node1 192.168.1.1")
+            host.calicoctl("container add node2 192.168.1.2")
+
+            # Now add the profiles.
             host.calicoctl("profile TEST_GROUP member add node1")
-        with self.assertRaises(CalledProcessError):
             host.calicoctl("profile TEST_GROUP member add node2")
 
-        # Add the nodes to Calico networking.
-        host.calicoctl("container add node1 192.168.1.1")
-        host.calicoctl("container add node2 192.168.1.2")
+            # Inspect the nodes
+            host.execute("docker inspect node1")
+            host.execute("docker inspect node2")
 
-        # Now add the profiles.
-        host.calicoctl("profile TEST_GROUP member add node1")
-        host.calicoctl("profile TEST_GROUP member add node2")
+            # Check it works
+            ping = partial(host.execute,
+                           "docker exec node1 ping 192.168.1.2 -c 1 -W 1")
+            retry_until_success(ping, ex_class=CalledProcessError)
 
-        # Inspect the nodes
-        host.execute("docker inspect node1")
-        host.execute("docker inspect node2")
+            host.execute("docker exec node1 ping 192.168.1.1 -c 1")
+            host.execute("docker exec node1 ping 192.168.1.2 -c 1")
+            host.execute("docker exec node2 ping 192.168.1.1 -c 1")
+            host.execute("docker exec node2 ping 192.168.1.2 -c 1")
 
-        # Check it works
-        ping = partial(host.execute,
-                       "docker exec node1 ping 192.168.1.2 -c 1 -W 1")
-        retry_until_success(ping, ex_class=CalledProcessError)
-
-        host.execute("docker exec node1 ping 192.168.1.1 -c 1")
-        host.execute("docker exec node1 ping 192.168.1.2 -c 1")
-        host.execute("docker exec node2 ping 192.168.1.1 -c 1")
-        host.execute("docker exec node2 ping 192.168.1.2 -c 1")
-
-        # Test the teardown commands
-        host.calicoctl("profile remove TEST_GROUP")
-        host.calicoctl("container remove node1")
-        host.calicoctl("container remove node2")
-        host.calicoctl("pool remove 192.168.0.0/16")
-        host.calicoctl("node stop")
+            # Test the teardown commands
+            host.calicoctl("profile remove TEST_GROUP")
+            host.calicoctl("container remove node1")
+            host.calicoctl("container remove node2")
+            host.calicoctl("pool remove 192.168.0.0/16")
+            host.calicoctl("node stop")

--- a/calico_containers/tests/st/test_profile_commands.py
+++ b/calico_containers/tests/st/test_profile_commands.py
@@ -7,28 +7,33 @@ class TestProfileCommands(TestBase):
         """
         Test that the profile rule update command successfully updates.
         """
-        host = DockerHost('host', start_calico=False)
+        with DockerHost('host', start_calico=False) as host:
 
-        host.calicoctl("profile add TEST_PROFILE")
+            host.calicoctl("profile add TEST_PROFILE")
 
-        json = ('{ "id": "TEST_PROFILE", '
-                  '"inbound_rules": [ { "action": "allow", "src_tag": "TEST_PROFILE" }, '
-                                     '{ "action": "deny" } ], '
-                  '"outbound_rules": [ { "action": "deny" } ] }')
+            json = ('{ "id": "TEST_PROFILE", '
+                    '"inbound_rules": [ '
+                    '{ "action": "allow", '
+                    '"src_tag": "TEST_PROFILE" }, '
+                    '{ "action": "deny" } ], '
+                    '"outbound_rules": [ { "action": "deny" } ] }')
 
-        calicoctl = "/code/dist/calicoctl %s"
-        host.execute("echo '%s' | " % json + calicoctl % "profile TEST_PROFILE rule update")
+            calicoctl = "/code/dist/calicoctl %s"
+            host.execute("echo '%s' | " % json + calicoctl %
+                         "profile TEST_PROFILE rule update")
 
-        self.assertIn('1 deny', host.calicoctl("profile TEST_PROFILE rule show").rstrip())
-        json_piece = '"outbound_rules": [\n    {\n      "action": "deny"'
-        self.assertIn(json_piece, host.calicoctl("profile TEST_PROFILE rule json").rstrip())
+            self.assertIn('1 deny',
+                          host.calicoctl("profile TEST_PROFILE rule show"))
+            json_piece = '"outbound_rules": [\n    {\n      "action": "deny"'
+            self.assertIn(json_piece,
+                          host.calicoctl("profile TEST_PROFILE rule json"))
 
-        # Test that adding and removing a tag works.
-        self.assertNotIn("TEST_TAG", self.show_tag(host))
-        host.calicoctl("profile TEST_PROFILE tag add TEST_TAG")
-        self.assertIn("TEST_TAG", self.show_tag(host))
-        host.calicoctl("profile TEST_PROFILE tag remove TEST_TAG")
-        self.assertNotIn("TEST_TAG", self.show_tag(host))
+            # Test that adding and removing a tag works.
+            self.assertNotIn("TEST_TAG", self.show_tag(host))
+            host.calicoctl("profile TEST_PROFILE tag add TEST_TAG")
+            self.assertIn("TEST_TAG", self.show_tag(host))
+            host.calicoctl("profile TEST_PROFILE tag remove TEST_TAG")
+            self.assertNotIn("TEST_TAG", self.show_tag(host))
 
     def show_tag(self, host):
         return host.calicoctl("profile TEST_PROFILE tag show").rstrip()

--- a/calico_containers/tests/st/utils.py
+++ b/calico_containers/tests/st/utils.py
@@ -1,5 +1,3 @@
-import sh
-from sh import docker
 import socket
 from time import sleep
 import os
@@ -21,31 +19,6 @@ def get_ip():
         ip = s.getsockname()[0]
         s.close()
     return ip
-
-
-def cleanup_inside(name):
-    """
-    Clean the inside of a container by deleting the containers and images within it.
-    """
-    docker("exec", "-t", name, "bash", "-c",
-           "docker rm -f $(docker ps -qa) ; docker rmi $(docker images -qa)",
-           _ok_code=[0,
-                     1,  # Caused by 'docker: "rm" requires a minimum of 1 argument.' et al.
-                     127,  # Caused by '"docker": no command found'
-                     255,  # Caused by '"bash": executable file not found in $PATH'
-                    ]
-          )
-
-
-def delete_container(name):
-    """
-    Cleanly delete a container.
-    """
-    # We *must* remove all inner containers and images before removing the outer
-    # container. Otherwise the inner images will stick around and fill disk.
-    # https://github.com/jpetazzo/dind#important-warning-about-disk-usage
-    cleanup_inside(name)
-    sh.docker.rm("-f", name, _ok_code=[0, 1])
 
 
 def retry_until_success(function, retries=10, ex_class=Exception):


### PR DESCRIPTION
DockerHost becomes a context manager so you can use it like

```
with DockerHost('host') as host:
	# Do the stuff.
```

Fixes up existing STs to use this form.