### PR TITLE
Disable BIRD's recursive route check for GCE compatibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,5 +73,5 @@ COPY calico_containers/adapter /calico_containers/adapter
 COPY calico_containers/__init__.py /calico_containers/
 
 # Copy patched BIRD daemon with tunnel support.
-RUN curl -L https://www.dropbox.com/s/ymbvyi6388h92qg/bird?dl=1 -o /usr/sbin/bird && \
+RUN curl -L https://www.dropbox.com/s/xjhfckzse25x554/bird-6af4e30d3fccb0c6bd184e9168294c807e1e6d68?dl=1 -o /usr/sbin/bird && \
     chmod +x /usr/sbin/bird

--- a/docs/GCE.md
+++ b/docs/GCE.md
@@ -79,10 +79,6 @@ export private_ip=$(curl "$metadata_url/instance/network-interfaces/0/ip" -H "Me
 
 # Start the calico node service:
 sudo ./calicoctl node --ip=$private_ip
-
-# Work-around a [BIRD routing issue](http://marc.info/?l=bird-users&m=139809577125938&w=2)
-# This tells BIRD that it's directly connected to the upstream GCE router.
-sudo ip addr add $private_ip peer 10.240.0.1 dev ens4v1
 ```
 Then, on any one of the hosts, run this command to create an IP pool with IP-in-IP and NAT enabled:
 ```


### PR DESCRIPTION
@robbrockbank This pulls the version of BIRD that I built from my PR and removes the work-around from the instructions: https://github.com/Metaswitch/calico-bird/pull/2

Blocked on @spikecurtis's review of that PR, I suppose.