### PR TITLE
Fix ICMP handling in rules/parsing

### DIFF
--- a/calico_containers/adapter/datastore.py
+++ b/calico_containers/adapter/datastore.py
@@ -107,6 +107,7 @@ class Rule(dict):
                     "dst_ports",
                     "dst_net",
                     "icmp_type",
+                    "icmp_code",
                     "action"]
 
     def __init__(self, **kwargs):

--- a/calico_containers/adapter/datastore.py
+++ b/calico_containers/adapter/datastore.py
@@ -156,6 +156,8 @@ class Rule(dict):
             out.append(self["protocol"])
         if "icmp_type" in self:
             out.extend(["type", str(self["icmp_type"])])
+        if "icmp_code" in self:
+            out.extend(["code", str(self["icmp_code"])])
 
         if "src_tag" in self or "src_ports" in self or "src_net" in self:
             out.append("from")

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -805,6 +805,25 @@ def profile_rule_add_remove(
 
     :return:
     """
+    if icmp_type is not None:
+        try:
+            icmp_type = int(icmp_type)
+        except ValueError:
+            print "ICMP type should be an integer"
+            sys.exit(1)
+        if not (0 <= icmp_type < 255):  # Felix doesn't support 255.
+            print "ICMP type out of range"
+            sys.exit(1)
+    if icmp_code is not None:
+        try:
+            icmp_code = int(icmp_code)
+        except ValueError:
+            print "ICMP code should be an integer"
+            sys.exit(1)
+        if not (0 <= icmp_code < 255):  # Felix doesn't support 255.
+            print "ICMP code out of range"
+            sys.exit(1)
+
     # Convert the input into a Rule.
     rule_dict = {k: v for (k, v) in locals().iteritems()
                  if k in Rule.ALLOWED_KEYS and v is not None}


### PR DESCRIPTION
We were using strings instead of ints when generating rules and the Rule object was missing support for icmp_code.