### PR TITLE
Calicoctl changes, getting started update

### DIFF
--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -37,7 +37,6 @@ Usage:
   calicoctl profile <PROFILE> rule show
   calicoctl profile <PROFILE> rule json
   calicoctl profile <PROFILE> rule update
-  calicoctl profile <PROFILE> member add <CONTAINER>
   calicoctl pool (add|remove) <CIDR> [--ipip] [--nat-outgoing]
   calicoctl pool show [--ipv4 | --ipv6]
   calicoctl default-node-as [<AS_NUM>]
@@ -606,41 +605,6 @@ def profile_add(profile_name):
         # Create the profile.
         client.create_profile(profile_name)
         print "Created profile %s" % profile_name
-
-
-def profile_add_container(container_name, profile_name):
-    """
-    Add a container (on this host) to the profile with the given name.  This
-    adds the first endpoint on the container to the profile.
-
-    This method is deprecated and may be removed in future versions of
-    calicoctl.
-
-    :param container_name: The Docker container name or ID.
-    :param profile_name:  The Calico policy profile name.
-    :return: None.
-    """
-    info = get_container_info_or_exit(container_name)
-    container_id = info["Id"]
-
-    # Check the container is actually running.
-    if not info["State"]["Running"]:
-        print "%s is not currently running." % container_name
-        sys.exit(1)
-
-    # Check that the container is already networked
-    try:
-        endpoint_id = client.get_endpoint_id_from_cont(hostname, container_id)
-    except KeyError:
-        print "Failed to add container to profile.\n"
-        print_container_not_in_calico_msg(container_name)
-        sys.exit(1)
-
-    assert not isinstance(profile_name, list), "Expecting single profile"
-
-    # Call through to the container profile set method to add the profile.
-    endpoint_profile_set(hostname, ORCHESTRATOR_ID, container_id, endpoint_id,
-                         [profile_name])
 
 
 def profile_remove(profile_name):
@@ -1844,9 +1808,6 @@ if __name__ == '__main__':
                 elif arguments["remove"]:
                     profile_tag_remove(arguments["<PROFILE>"],
                                        arguments["<TAG>"])
-            elif arguments["member"]:
-                profile_add_container(arguments["<CONTAINER>"],
-                                      arguments["<PROFILE>"])
             elif arguments["rule"]:
                 if arguments["show"]:
                     profile_rule_show(arguments["<PROFILE>"],

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -52,7 +52,6 @@ Usage:
   calicoctl endpoint show [--host=<HOSTNAME>] [--orchestrator=<ORCHESTRATOR_ID>] [--workload=<WORKLOAD_ID>] [--endpoint=<ENDPOINT_ID>] [--detailed]
   calicoctl endpoint <ENDPOINT_ID> profile (append|remove|set) [--host=<HOSTNAME>] [--orchestrator=<ORCHESTRATOR_ID>] [--workload=<WORKLOAD_ID>]  [<PROFILES>...]
   calicoctl endpoint <ENDPOINT_ID> profile show [--host=<HOSTNAME>] [--orchestrator=<ORCHESTRATOR_ID>] [--workload=<WORKLOAD_ID>]
-  calicoctl reset
   calicoctl diags [--upload]
   calicoctl checksystem [--fix]
   calicoctl restart-docker-with-alternative-unix-socket
@@ -592,11 +591,6 @@ def status():
                                      "birdc6 -s "
                                      "/etc/service/bird6/bird6.ctl"])
         print docker_client.exec_start(bird6_cmd)
-
-
-def reset():
-    print "Removing all data from data store"
-    client.remove_all_data()
 
 
 def profile_add(profile_name):
@@ -1808,8 +1802,6 @@ if __name__ == '__main__':
             status()
         elif arguments["checksystem"]:
             checksystem(arguments["--fix"], quit_if_error=True)
-        elif arguments["reset"]:
-            reset()
         elif arguments["endpoint"]:
             if arguments["profile"]:
                 if arguments["append"]:

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -916,19 +916,19 @@ def ip_pool_show(version):
     :return: None
     """
     assert version in ("v4", "v6")
-    headings = ["IP%s CIDR" % version]
-    if version == "v4":
-        headings.append("IP-IP")
+    headings = ["IP%s CIDR" % version, "Options"]
     pools = client.get_ip_pools(version)
     x = PrettyTable(headings)
     for pool in pools:
-        row = [pool]
+        enabled_options = []
         if version == "v4":
             cfg = client.get_ip_pool_config(version, pool)
             if "ipip" in cfg:
-                row.append("Enabled")
-            else:
-                row.append("Disabled")
+                enabled_options.append("ipip")
+            if "masquerade" in cfg:
+                enabled_options.append("nat-outgoing")
+        # convert option array to string
+        row = [pool, ','.join(enabled_options)]
         x.add_row(row)
     print x.get_string(sortby=headings[0])
 

--- a/calico_containers/tests/st/test_duplicate_ips.py
+++ b/calico_containers/tests/st/test_duplicate_ips.py
@@ -41,11 +41,20 @@ class TestDuplicateIps(TestBase):
         host1.calicoctl("profile add TEST_PROFILE")
 
         # Add everyone to the same profile
-        host1.calicoctl("profile TEST_PROFILE member add %s" % workload1)
-        host1.calicoctl("profile TEST_PROFILE member add %s" % dup1)
-        host2.calicoctl("profile TEST_PROFILE member add %s" % workload2)
-        host2.calicoctl("profile TEST_PROFILE member add %s" % dup2)
-        host3.calicoctl("profile TEST_PROFILE member add %s" % workload3)
+        workload1_epid = host1.calicoctl("container %s endpoint-id show" % workload1).strip()
+        host1.calicoctl("endpoint %s profile append TEST_PROFILE" % workload1_epid)
+
+        dup1_epid = host1.calicoctl("container %s endpoint-id show" % dup1).strip()
+        host1.calicoctl("endpoint %s profile append TEST_PROFILE" % dup1_epid)
+
+        workload2_epid = host2.calicoctl("container %s endpoint-id show" % workload2).strip()
+        host2.calicoctl("endpoint %s profile append TEST_PROFILE" % workload2_epid)
+
+        dup2_epid = host2.calicoctl("container %s endpoint-id show" % dup2).strip()
+        host2.calicoctl("endpoint %s profile append TEST_PROFILE" % dup2_epid)
+
+        workload3_dpid = host3.calicoctl("container %s endpoint-id show" % workload3).strip()
+        host3.calicoctl("endpoint %s profile append TEST_PROFILE" % workload3_dpid)
 
         # Check for standard connectivity
         workload1.assert_can_ping(dup_ip, retries=3)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -87,18 +87,28 @@ Create some profiles (this can be done on either host)
     ./calicoctl profile add PROF_B
     ./calicoctl profile add PROF_D
 
-Now add the containers to the profile (note that `profile add` works from any Calico node, but `profile <PROFILE> member add` only works from the Calico node where the container is hosted).
+When each container is added to calico, an "endpoint" is registered for each container's interface. Containers are only allowed to communicate with one another when both of their endpoints are assigned the same profile. To assign a profile to an endpoint, we will first get the endpoint's ID with `calicoctl container <CONTAINER> endpoint-id show`, then paste it into the `calicoctl endpoint <ENDPOINT_ID> profile append [<PROFILES>]`  command.
 
 On core-01:
 
-    ./calicoctl profile PROF_A_C_E member add workload-A
-    ./calicoctl profile PROF_B member add workload-B
-    ./calicoctl profile PROF_A_C_E member add workload-C
+    ./calicoctl container workload-A endpoint-id show
+    ./calicoctl endpoint <workload-A's Endpoint-ID> profile append PROF_A_C_E
+
+    ./calicoctl endpoint workload-B endpoint-id show
+    ./calicoctl endpoint <workload-B's Endpoint-ID> profile append PROF_B
+
+    ./calicoctl endpoint workload-C endpoint-id show
+    ./calicoctl endpoint <workload-C's Endpoint-ID> profile append PROF_A_C_E
 
 On core-02:
 
-    ./calicoctl profile PROF_D member add workload-D
-    ./calicoctl profile PROF_A_C_E member add workload-E
+    ./calicoctl endpoint workload-D endpoint-id show
+    ./calicoctl endpoint <workload-D's Endpoint-ID> profile append PROF_D
+
+    ./calicoctl endpoint workload-E endpoint-id show
+    ./calicoctl endpoint <workload-E's Endpoint-ID> profile append PROF_A_C_E
+
+*Note that creating a new profile with `calicoctl profile add` will work on any Calico node, but assigning an endpoint a profile with `calicoctl endpoint <ENDPOINT_ID> profile append` will only work on the Calico node where the container is hosted.*
 
 Now, check that A can ping C (192.168.1.3) and E (192.168.1.5):
 
@@ -150,14 +160,16 @@ On core-01
 
     docker run -e CALICO_IP=fd80:24e2:f998:72d6::1:1 --name workload-F -tid phusion/baseimage:0.9.16
     ./calicoctl profile add PROF_F_G
-    ./calicoctl profile PROF_F_G member add workload-F
+    ./calicoctl container workload-F endpoint-id show
+    ./calicoctl endpoint <workload-F's Endpoint-ID>  profile append PROF_F_G
 
 Note that we have used `phusion/baseimage:0.9.16` instead of `busybox`.  Busybox doesn't support IPv6 versions of network tools like ping.  Baseimage was chosen since it is the base for the Calico service images, and thus won't require an additional download, but of course you can use whatever image you'd like.
 
 One core-02
 
     docker run -e CALICO_IP=fd80:24e2:f998:72d6::1:2 --name workload-G -tid phusion/baseimage:0.9.16
-    ./calicoctl profile PROF_F_G member add workload-G
+    ./calicoctl container workload-G endpoint-id show
+    ./calicoctl endpoint <workload-G's Endpoint-ID> profile append PROF_F_G
     docker exec workload-G ping6 -c 4 fd80:24e2:f998:72d6::1:1
 
 [calico-coreos-vagrant]: https://github.com/Metaswitch/calico-coreos-vagrant-example

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -122,10 +122,6 @@ Also check that A cannot ping B (192.168.1.2) or D (192.168.1.4):
 
 By default, profiles are configured so that their members can communicate with one another, but workloads in other profiles cannot reach them.  B and D are in their own profiles so shouldn't be able to ping anyone else.
 
-Finally, to clean everything up (without doing a `vagrant destroy`), you can run
-
-    sudo ./calicoctl reset
-
 
 ## IPv6
 To connect your containers with IPv6, first make sure your Docker hosts each have an IPv6 address assigned.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -13,8 +13,6 @@ If you see this exception, it means `calicoctl` can't communicate with your etcd
 ## Basic checks
 Running `ip route` shows what routes have been programmed. Routes from other hosts should show that they are programmed by bird.
 
-If you have rebooted your hosts, then some configuration can get lost. It's best to run a `sudo ./calicoctl reset` and start again.
-
 If your hosts reboot themselves with a message from `locksmithd` your cached CoreOS image is out of date.  Use `vagrant box update` to pull the new version.  I recommend doing a `vagrant destroy; vagrant up` to start from a clean slate afterwards.
 
 If you hit issues, please raise tickets. Diags can be collected and easily uploaded with the `sudo ./calicoctl diags --upload` command.


### PR DESCRIPTION
- Removed `calicoctl reset`
- Removed `profile member add`
- Changed title of column in `ip_pool_show` from ip-ip to Options
- Updated getting started documentation to use new endpoint command