### PR TITLE
datastore cleanup

### DIFF
--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -218,7 +218,9 @@ def container_add(container_name, ip, interface):
 
     # Check if the container already exists
     try:
-        _ = client.get_endpoint_id_from_cont(hostname, container_id)
+        _ = client.get_endpoint(hostname=hostname,
+                                orchestrator_id=ORCHESTRATOR_ID,
+                                workload_id=container_id)
     except KeyError:
         # Calico doesn't know about this container.  Continue.
         pass
@@ -289,16 +291,14 @@ def container_remove(container_name):
 
     # Find the endpoint ID. We need this to find any ACL rules
     try:
-        endpoint_id = client.get_endpoint_id_from_cont(hostname, workload_id)
+        endpoint = client.get_endpoint(hostname=hostname,
+                                       orchestrator_id=ORCHESTRATOR_ID,
+                                       workload_id=workload_id)
     except KeyError:
         print "Container %s doesn't contain any endpoints" % container_name
         sys.exit(1)
 
     # Remove any IP address assignments that this endpoint has
-    endpoint = client.get_endpoint(hostname=hostname,
-                                   orchestrator_id=ORCHESTRATOR_ID,
-                                   workload_id=workload_id,
-                                   endpoint_id=endpoint_id)
     for net in endpoint.ipv4_nets | endpoint.ipv6_nets:
         assert(net.size == 1)
         ip = net.ip
@@ -1075,11 +1075,9 @@ def container_ip_add(container_name, ip, version, interface):
 
     # Check that the container is already networked
     try:
-        endpoint_id = client.get_endpoint_id_from_cont(hostname, container_id)
         endpoint = client.get_endpoint(hostname=hostname,
                                        orchestrator_id=ORCHESTRATOR_ID,
-                                       workload_id=container_id,
-                                       endpoint_id=endpoint_id)
+                                       workload_id=container_id)
     except KeyError:
         print "Failed to add IP address to container.\n"
         print_container_not_in_calico_msg(container_name)
@@ -1149,11 +1147,9 @@ def container_ip_remove(container_name, ip, version, interface):
 
     # Check that the container is already networked
     try:
-        endpoint_id = client.get_endpoint_id_from_cont(hostname, container_id)
         endpoint = client.get_endpoint(hostname=hostname,
                                        orchestrator_id=ORCHESTRATOR_ID,
-                                       workload_id=container_id,
-                                       endpoint_id=endpoint_id)
+                                       workload_id=container_id)
         if address.version == 4:
             nets = endpoint.ipv4_nets
         else:

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -268,7 +268,7 @@ def container_add(container_name, ip, interface):
                                      proc_alias="/proc")
 
     # Register the endpoint
-    client.set_endpoint(hostname, container_id, endpoint)
+    client.set_endpoint(hostname, ORCHESTRATOR_ID, container_id, endpoint)
 
     print "IP %s added to %s" % (ip, container_name)
 
@@ -310,10 +310,10 @@ def container_remove(container_name):
                 client.unassign_address(pool, ip)
 
     # Remove the endpoint
-    netns.remove_endpoint(endpoint_id)
+    netns.remove_endpoint(endpoint.endpoint_id)
 
     # Remove the container from the datastore.
-    client.remove_container(hostname, workload_id)
+    client.remove_container(hostname, ORCHESTRATOR_ID, workload_id)
 
     print "Removed Calico interface from %s" % container_name
 

--- a/calico_containers/docker_plugin.py
+++ b/calico_containers/docker_plugin.py
@@ -29,6 +29,7 @@ FIXED_MAC = "EE:EE:EE:EE:EE:EE"
 
 CONTAINER_NAME = "libnetwork"
 
+ORCHESTRATOR_ID = "docker"
 # How long to wait (seconds) for IP commands to complete.
 IP_CMD_TIMEOUT = 5
 
@@ -143,7 +144,7 @@ def create_endpoint():
 
     # Finally, write the endpoint to the datastore.
     try:
-        client.set_endpoint(hostname, CONTAINER_NAME, ep)
+        client.set_endpoint(hostname, ORCHESTRATOR_ID, CONTAINER_NAME, ep)
     except DataStoreError as e:
         # We've failed to write the endpoint to the datastore.
         # Back out the IP assignments and the veth creation.

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -830,18 +830,8 @@ class DatastoreClient(object):
         :param profile_name: Unique string name of the profile.
         :return: a list of Endpoint objects.
         """
-        eps = []
-        try:
-            endpoints = self.etcd_client.read(ALL_ENDPOINTS_PATH,
-                                              recursive=True).leaves
-        except EtcdKeyNotFound:
-            pass
-        else:
-            for child in endpoints:
-                ep = Endpoint.from_json(child.key, child.value)
-                if ep and profile_name in ep.profile_ids:
-                    eps.append(ep)
-        return eps
+        return [endpoint for endpoint in self.get_endpoints()
+                if profile_name in endpoint.profile_ids]
 
     @handle_errors
     def profile_update_tags(self, profile):

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -403,6 +403,11 @@ class Endpoint(object):
         A less strict 'equals' function, which compares provided parameters to
         the current endpoint object.
 
+        :param hostname: The hostname to compare to
+        :param orchestrator_id: The orchestrator ID to compare to.
+        :param workload_id: The workload ID to compare to
+        :param endpoint_id: The endpoint ID to compare to
+
         :return: True if the provided parameters match the Endpoint's
         parameters, False if any of the provided parameters are different from
         the Endpoint's parameters.
@@ -990,6 +995,12 @@ class DatastoreClient(object):
         Raises a MultipleEndpointsMatch exception if more than one endpoint
         matches.
 
+        :param hostname: The hostname that the endpoint lives on.
+        :param orchestrator_id: The workload (or container) that the endpoint
+        belongs to.
+        :param workload_id: The workload (or container) that the endpoint
+        belongs to.
+        :param endpoint_id: The ID of the endpoint
         :return: An Endpoint Object
         """
         eps = self.get_endpoints(hostname=hostname,
@@ -1014,6 +1025,8 @@ class DatastoreClient(object):
         Write a single endpoint object to the datastore.
 
         :param hostname: The hostname for the Docker hosting this container.
+        :param orchestrator_id: The orchestrator the the workload (or container)
+        belongs to.
         :param container_id: The Docker container ID.
         :param endpoint: The Endpoint to add to the container.
         """
@@ -1097,6 +1110,8 @@ class DatastoreClient(object):
         """
         Remove a container from the datastore.
         :param hostname: The name of the host the container is on.
+        :param orchestrator_id: The orchestrator the workload (or container)
+        belongs to.
         :param container_id: The Docker container ID.
         :return: None.
         """

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -945,33 +945,6 @@ class DatastoreClient(object):
         self.update_endpoint(ep)
 
     @handle_errors
-    def get_endpoint_id_from_cont(self, hostname, container_id):
-        """
-        Get a single endpoint ID from a container ID.
-
-        :param hostname: The host the container is on.
-        :param container_id: The Docker container ID.
-        :return: Endpoint ID as a string.
-        """
-        ep_path = LOCAL_ENDPOINTS_PATH % {"hostname": hostname,
-                                          "container_id": container_id}
-        try:
-            endpoints = self.etcd_client.read(ep_path).leaves
-        except EtcdKeyNotFound:
-            # Re-raise with better message
-            raise KeyError("Container with ID %s was not found." %
-                           container_id)
-
-        # Get the first endpoint & ID
-        try:
-            endpoint = endpoints.next()
-            (_, _, _, _, _, _, _, _, _, endpoint_id) = endpoint.key.split("/", 9)
-            return endpoint_id
-        except StopIteration:
-            raise NoEndpointForContainer(
-                "Container with ID %s has no endpoints." % container_id)
-
-    @handle_errors
     def get_endpoints(self, hostname=None, orchestrator_id=None,
                       workload_id=None, endpoint_id=None):
         """

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -995,35 +995,6 @@ class TestDatastoreClient(unittest.TestCase):
         assert_not_equal(ep._original_json, original_json)
         assert_equals(ep._original_json, ep.to_json())
 
-    def test_get_endpoint_id_from_cont(self):
-        """
-        Test get_endpoint_id_from_cont() when container and endpoint exist.
-        """
-        self.etcd_client.read.side_effect = \
-            get_mock_read_2_ep_for_cont(TEST_CONT_ENDPOINTS_PATH, None)
-        endpoint_id = self.datastore.get_endpoint_id_from_cont(TEST_HOST,
-                                                               TEST_CONT_ID)
-        assert_equal(endpoint_id, EP_12.endpoint_id)
-
-    def test_get_endpoint_id_from_cont_no_ep(self):
-        """
-        Test get_endpoint_id_from_cont() when the container exists, but there are
-        no endpoints.
-        """
-        self.etcd_client.read.side_effect = mock_read_0_ep_for_cont
-        assert_raises(NoEndpointForContainer,
-                      self.datastore.get_endpoint_id_from_cont,
-                      TEST_HOST, TEST_CONT_ID)
-
-    def test_get_endpoint_id_from_cont_no_cont(self):
-        """
-        Test get_endpoint_id_from_cont() when the container doesn't exist.
-        """
-        self.etcd_client.read.side_effect = EtcdKeyNotFound
-        assert_raises(KeyError,
-                      self.datastore.get_endpoint_id_from_cont,
-                      TEST_HOST, TEST_CONT_ID)
-
     def test_get_endpoints_exists(self):
         """
         Test get_endpoints() passing in various numbers of parameters, with

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -51,12 +51,12 @@ ALL_PROFILES_PATH = CALICO_V_PATH + "/policy/profile/"
 ALL_ENDPOINTS_PATH = CALICO_V_PATH + "/host/"
 ALL_HOSTS_PATH = CALICO_V_PATH + "/host/"
 TEST_NODE_BGP_PEERS_PATH = TEST_HOST_PATH + "/bgp_peer_v4/"
-TEST_ORCHESTRATORS_PATH = CALICO_V_PATH + "/host/TEST_HOST/workload/"
+TEST_ORCHESTRATORS_PATH = CALICO_V_PATH + "/host/TEST_HOST/"
 TEST_WORKLOADS_PATH = CALICO_V_PATH + "/host/TEST_HOST/workload/docker/"
 TEST_ENDPOINT_PATH = CALICO_V_PATH + "/host/TEST_HOST/workload/docker/1234/" \
                                      "endpoint/1234567890ab"
 TEST_CONT_ENDPOINTS_PATH = CALICO_V_PATH + "/host/TEST_HOST/workload/docker/" \
-                                          "1234/endpoint/"
+                                          "1234/"
 TEST_CONT_PATH = CALICO_V_PATH + "/host/TEST_HOST/workload/docker/1234/"
 CONFIG_PATH = CALICO_V_PATH + "/config/"
 BGP_NODE_DEF_AS_PATH = CALICO_V_PATH + "/config/bgp_as"
@@ -972,7 +972,7 @@ class TestDatastoreClient(unittest.TestCase):
         Test set_endpoint().
         """
         EP_12._original_json = ""
-        self.datastore.set_endpoint(TEST_HOST, TEST_CONT_ID, EP_12)
+        self.datastore.set_endpoint(TEST_HOST, TEST_ORCH_ID, TEST_CONT_ID, EP_12)
         self.etcd_client.write.assert_called_once_with(TEST_ENDPOINT_PATH,
                                                        EP_12.to_json())
         assert_equal(EP_12._original_json, EP_12.to_json())
@@ -1129,7 +1129,7 @@ class TestDatastoreClient(unittest.TestCase):
         """
         Test remove_container()
         """
-        self.datastore.remove_container(TEST_HOST, TEST_CONT_ID)
+        self.datastore.remove_container(TEST_HOST, TEST_ORCH_ID, TEST_CONT_ID)
         self.etcd_client.delete.assert_called_once_with(TEST_CONT_PATH,
                                                         recursive=True,
                                                         dir=True)
@@ -1141,7 +1141,7 @@ class TestDatastoreClient(unittest.TestCase):
         exist.
         """
         self.etcd_client.delete.side_effect = EtcdKeyNotFound
-        self.datastore.remove_container(TEST_HOST, TEST_CONT_ID)
+        self.datastore.remove_container(TEST_HOST, TEST_ORCH_ID, TEST_CONT_ID)
 
     def test_get_bgp_peers(self):
         """


### PR DESCRIPTION
- Replaced references to "docker" in datastore by abstracting with orchestrator
- Modified other functions to use the new and optimized get_endpoints
- Removed obsolete shownodes and get_host functionality
See individual commits for easier view