### PR TITLE
Endpoint deletion in Libnetwork plugin

### DIFF
--- a/calico_containers/docker_plugin.py
+++ b/calico_containers/docker_plugin.py
@@ -187,14 +187,13 @@ def delete_endpoint():
         app.logger.exception(e)
         app.logger.warning("Failed to unassign IPs for endpoint %s", ep_id)
 
-    try:
-        # TODO - Fix
-        # client.remove_endpoint(hostname, "docker", CONTAINER_NAME, ep_id)
-        pass
-    except DataStoreError as e:
-        app.logger.exception(e)
-        app.logger.warning("Failed to remove endpoint %s from datastore",
-                           ep_id)
+    if ep:
+        try:
+            client.remove_endpoint(ep)
+        except DataStoreError as e:
+            app.logger.exception(e)
+            app.logger.warning("Failed to remove endpoint %s from datastore",
+                               ep_id)
 
     # libnetwork expects us to delete the veth pair.  (Note that we only need
     # to delete one end).

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -675,6 +675,19 @@ class DatastoreClient(object):
         endpoint._original_json = new_json
 
     @handle_errors
+    def remove_endpoint(self, endpoint):
+        """
+        Remove a single endpoint object from the datastore.
+
+        :param endpoint: The Endpoint to remove.
+        """
+        ep_path = ENDPOINT_PATH % {"hostname": endpoint.hostname,
+                                   "orchestrator_id": endpoint.orchestrator_id,
+                                   "workload_id": endpoint.workload_id,
+                                   "endpoint_id": endpoint.endpoint_id}
+        self.etcd_client.delete(ep_path, dir=True, recursive=True)
+
+    @handle_errors
     def get_default_next_hops(self, hostname):
         """
         Get the next hop IP addresses for default routes on the given host.

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -979,6 +979,15 @@ class TestDatastoreClient(unittest.TestCase):
                                                        EP_12.to_json())
         assert_equal(EP_12._original_json, EP_12.to_json())
 
+    def test_remove_endpoint(self):
+        """
+        Test remove_endpoint().
+        """
+        self.datastore.remove_endpoint(EP_12)
+        self.etcd_client.delete.assert_called_once_with(TEST_ENDPOINT_PATH,
+                                                        recursive=True,
+                                                        dir=True)
+
     def test_update_endpoint(self):
         """
         Test update_endpoint().


### PR DESCRIPTION
We had a TODO from when we'd moved code around.
Reinstate the code and add a UT for it.