### PR TITLE
Update demo calicoctl version to be static, not latest

### DIFF
--- a/docs/AWS.md
+++ b/docs/AWS.md
@@ -111,7 +111,7 @@ Run the following commands to SSH into each node and set up Calico:
 ssh -i mykey.pem core@<instance IP>
 
 # Download calicoctl and make it executable:
-wget http://projectcalico.org/latest/calicoctl
+wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.8/calicoctl
 chmod +x ./calicoctl
 
 # Grab our private IP from the metadata service:

--- a/docs/CalicoSwarm.md
+++ b/docs/CalicoSwarm.md
@@ -56,7 +56,7 @@ export NODE_IP=<This Node's IP Address>
 Run the following set of commands on each **node** to download and start Calico.
 ```
 # Download calicoctl and make it executable:
-wget http://projectcalico.org/latest/calicoctl
+wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.8/calicoctl
 chmod +x ./calicoctl
 
 # Point this node at the etcd cluster
@@ -81,7 +81,7 @@ Run the following on your **client**:
 export MANAGER_IP=<Manager's IP Address>
 
 # Download calicoctl and make it executable:
-wget http://projectcalico.org/latest/calicoctl
+wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.8/calicoctl
 chmod +x ./calicoctl
 
 # Point this node at the etcd cluster

--- a/docs/DigitalOcean.md
+++ b/docs/DigitalOcean.md
@@ -21,7 +21,7 @@ write_files:
     content: |
       #!/bin/bash
       # Download calicoctl and make it executable:
-      wget http://projectcalico.org/latest/calicoctl
+      wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.8/calicoctl
       chmod +x ./calicoctl
       # Start the calico node service:
       sudo ./calicoctl node --ip=$private_ipv4

--- a/docs/GCE.md
+++ b/docs/GCE.md
@@ -81,7 +81,7 @@ gcloud compute ssh <instance name>
 On each node, run these commands to set up Calico:
 ```
 # Download calicoctl and make it executable:
-wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.7/calicoctl
+wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.8/calicoctl
 chmod +x ./calicoctl
 
 # Grab our private IP from the metadata service:

--- a/docs/Orchestrators.md
+++ b/docs/Orchestrators.md
@@ -24,9 +24,9 @@ Install and [bootstrap etcd](https://www.youtube.com/watch?v=duUTk8xxGbU)
  - If you don't run the proxy, you can manually set the etcd location using the `--etcd=` option on `calicoctl` commands.  Type `calicoctl help` for details.
  
 
-Get the calico binary onto each node. It's usually safe to just grab the latest [beta](http://projectcalico.org/latest/calicoctl):
+Get the calico binary onto each node:
 
-    wget http://projectcalico.org/latest/calicoctl
+    wget https://github.com/Metaswitch/calico-docker/releases/download/v0.4.8/calicoctl
 	chmod +x calicoctl
 
 Note that projectcalico.org is not an HA repository, so using this download URL is not recommended for any automated production installation process.  Alternatively, you can download a specific [release](https://github.com/Metaswitch/calico-docker/releases/) from github.  e.g.


### PR DESCRIPTION
The calicoctl version will soon change to work strictly with libnetwork, so the demos that use powerstrip should have a static version of calicoctl that supports powerstrip.