### PR TITLE
Fix stale APT cache when building calicoctl binary

### DIFF
--- a/build_calicoctl/Dockerfile
+++ b/build_calicoctl/Dockerfile
@@ -19,17 +19,16 @@ FROM ubuntu:14.04
 
 WORKDIR /code/
 
-RUN apt-get update
+RUN apt-get update && \
+    apt-get install -qy curl python-dev python-pip git libffi-dev libssl-dev
 
 # Make an etcd available as some UTs rely on it.
-RUN apt-get install -qy curl
 RUN curl -L  https://www.github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.tar.gz -o /tmp/etcd.tar.gz
 RUN tar -zxvf /tmp/etcd.tar.gz -C /tmp --strip-components=1
 
 # Install the python packages needed for running UTs and building calicoctl.
 # Git is installed to allow pip installation from a github repo and also so
 # that the right branch can be included if uploading coverage.
-RUN apt-get install -qy python-dev python-pip git libffi-dev libssl-dev
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt
 RUN pip install git+https://github.com/Metaswitch/python-etcd.git


### PR DESCRIPTION
Before this fix, the Dockerfile for calico/build had apt-get update and apt-get install on separate RUN lines.  This means Docker can cache the filesystem after the update.

After a few days, the apt-cache from that update gets stale, and an apt-get install tries to pull a discontinued point release of some library, and builds fail.

This fixes that by forcing them all on the same RUN line.