### PR TITLE
Run UT as root inside the container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,10 @@ dist/calicoctl: $(PYCALICO) calicobuild.created
 test: ut st
 
 ut: calicobuild.created
-	docker run --rm -v `pwd`/calico_containers:/code \
+	# Use the `root` user, since code coverage requires the /code directory to
+	# be writable.  It may not be writable for the `user` account inside the
+	# container.
+	docker run --rm -v `pwd`/calico_containers:/code -u root \
 	calico/build bash -c \
 	'/tmp/etcd -data-dir=/tmp/default.etcd/ >/dev/null 2>&1 & \
 	nosetests tests/unit -c nose.cfg'


### PR DESCRIPTION
The code coverage module requires the /code directory to be
writable, which it won't be if the UID of the user outside the container
doesn't match the UID of the `user` user inside the container.

Running under `user` is only required for pyinstaller, not UTs.