### PR TITLE
Add --detach=false option, to run calico-node in foreground

### DIFF
--- a/calico_containers/calico_ctl/node.py
+++ b/calico_containers/calico_ctl/node.py
@@ -98,7 +98,7 @@ def node(arguments):
                    detach=detach)
 
 
-def node_start(node_image, log_dir, ip="", ip6="", as_num=None, detach=True):
+def node_start(node_image, log_dir, ip, ip6, as_num, detach):
     """
     Create the calico-node container and establish Calico networking on this
     host.

--- a/calico_containers/calico_ctl/node.py
+++ b/calico_containers/calico_ctl/node.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Usage:
-  calicoctl node [--ip=<IP>] [--ip6=<IP6>] [--node-image=<DOCKER_IMAGE_NAME>] [--as=<AS_NUM>] [--log-dir=<LOG_DIR>]
+  calicoctl node [--ip=<IP>] [--ip6=<IP6>] [--node-image=<DOCKER_IMAGE_NAME>] [--as=<AS_NUM>] [--log-dir=<LOG_DIR>] [--detach=<DETACH>]
   calicoctl node stop [--force]
   calicoctl node bgp peer add <PEER_IP> as <AS_NUM>
   calicoctl node bgp peer remove <PEER_IP>
@@ -31,6 +31,8 @@ Options:
   --ip=<IP>                The local management address to use.
   --ip6=<IP6>              The local IPv6 management address to use.
   --as=<AS_NUM>            The default AS number for this node.
+  --detach=<DETACH>        Set "true" to run Calico service as detached,
+                           "false" to run in the foreground. [default: true]
   --ipv4                   Show IPv4 information only.
   --ipv6                   Show IPv6 information only.
 """
@@ -54,6 +56,8 @@ from utils import check_ip_version
 from netaddr import IPAddress
 from prettytable import PrettyTable
 from utils import get_container_ipv_from_arguments
+import sys
+import signal
 
 DEFAULT_IPV4_POOL = IPPool("192.168.0.0/16")
 DEFAULT_IPV6_POOL = IPPool("fd80:24e2:f998:72d6::/64")
@@ -84,14 +88,17 @@ def node(arguments):
     elif arguments.get("stop"):
         node_stop(arguments.get("--force"))
     else:
+        assert arguments.get("--detach") in ["true", "false"]
+        detach = arguments.get("--detach") == "true"
         node_start(ip=arguments.get("--ip"),
                    node_image=arguments['--node-image'],
                    log_dir=arguments.get("--log-dir"),
                    ip6=arguments.get("--ip6"),
-                   as_num=arguments.get("--as"))
+                   as_num=arguments.get("--as"),
+                   detach=detach)
 
 
-def node_start(node_image, log_dir, ip="", ip6="", as_num=None):
+def node_start(node_image, log_dir, ip="", ip6="", as_num=None, detach=True):
     """
     Create the calico-node container and establish Calico networking on this
     host.
@@ -101,6 +108,8 @@ def node_start(node_image, log_dir, ip="", ip6="", as_num=None):
     :param ip6:  The IPv6 address of the host (or None if not configured)
     :param as_num:  The BGP AS Number to use for this node.  If not specified
     the global default value will be used.
+    :param detach: True to run in Docker's "detached" mode, False to run
+    attached.
     :return:  None.
     """
     # Ensure log directory exists
@@ -211,6 +220,9 @@ def node_start(node_image, log_dir, ip="", ip6="", as_num=None):
     docker_client.start(container)
 
     print "Calico node is running with id: %s" % cid
+
+    if not detach:
+        _attach_and_stream(container)
 
 
 def node_stop(force):
@@ -360,3 +372,36 @@ def _find_or_pull_node_image(image_name, client):
             # TODO: Display proper status bar
             print "Pulling Docker image %s" % image_name
             client.pull(image_name)
+
+
+def _attach_and_stream(container):
+    """
+    Attach to a container and stream its stdout and stderr output to this
+    process's stdout, until the container stops.  If the user presses Ctrl-C or
+    the process is killed, also stop the Docker container.
+
+    Used to run the calico-node as a foreground attached service.
+
+    :param container: Docker container to attach to.
+    :return: None.
+    """
+
+    # Register a SIGTERM handler, so we shut down the container if this
+    # process is kill'd.
+    def handle_sigterm(sig, frame):
+        print "Got SIGTERM"
+        docker_client.stop(container)
+        sys.exit(0)
+    signal.signal(signal.SIGTERM, handle_sigterm)
+
+    output = docker_client.attach(container, stream=True)
+    try:
+        for raw_data in output:
+            sys.stdout.write(raw_data)
+    except KeyboardInterrupt:
+        # mainline.  someone press Ctrl-C.
+        print "Stopping Calico node..."
+    finally:
+        # Could either be this process is being killed, or output generator
+        # raises an exception.
+        docker_client.stop(container)

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -112,6 +112,10 @@ def validate_arguments(arguments):
             except ValueError:
                 asnum_ok = False
 
+        detach_ok = True
+        if arguments.get("<DETACH>") or arguments.get("--detach"):
+            detach_ok = arguments.get("--detach") in ["true", "false"]
+
         if not profile_ok:
             print_paragraph("Profile names must be < 40 character long and can "
                             "only contain numbers, letters, dots, dashes and "
@@ -131,9 +135,12 @@ def validate_arguments(arguments):
             print "Invalid ICMP type or code specified."
         if not asnum_ok:
             print "Invalid AS Number specified."
+        if not detach_ok:
+            print "Valid values for --detach are 'true' and 'false'"
 
         if not (profile_ok and ip_ok and ip6_ok and tag_ok and peer_ip_ok and
-                    container_ip_ok and cidr_ok and icmp_ok and asnum_ok):
+                container_ip_ok and cidr_ok and icmp_ok and asnum_ok and
+                detach_ok):
             sys.exit(1)
 
 

--- a/calico_containers/nose.cfg
+++ b/calico_containers/nose.cfg
@@ -1,4 +1,4 @@
 [nosetests]
 with-coverage=1
 cover-erase=1
-cover-package=pycalico
+cover-package=pycalico,calico_ctl

--- a/calico_containers/tests/unit/node_test.py
+++ b/calico_containers/tests/unit/node_test.py
@@ -1,0 +1,120 @@
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from mock import patch, Mock, call, ANY
+from calico_ctl.node import _attach_and_stream
+from docker import Client
+import sys
+import signal
+import os
+
+class TestAttachAndStream(unittest.TestCase):
+
+    @patch("calico_ctl.node.docker_client", spec=Client)
+    @patch("calico_ctl.node.sys", spec=sys)
+    def test_container_stops_normally(self, m_sys, m_docker_client):
+        """
+        Test _attach_and_stream when the container stops normally.
+
+        :return: None
+        """
+
+        # attach(..., stream=True) returns a generator.
+        def container_output_gen():
+            yield ("Some output\n")
+            yield ("from the container.")
+
+        m_docker_client.attach.return_value = container_output_gen()
+        m_stdout = Mock(spec=sys.stdout)
+        m_sys.stdout = m_stdout
+        m_container = Mock()
+        _attach_and_stream(m_container)
+
+        m_docker_client.attach.assert_called_once_with(m_container,
+                                                       stream=True)
+        self.assertFalse(m_container.called)
+        m_stdout.write.assert_has_calls([call("Some output\n"),
+                                         call("from the container.")])
+        m_docker_client.stop.assert_called_once_with(m_container)
+
+    @patch("calico_ctl.node.docker_client", spec=Client)
+    @patch("calico_ctl.node.sys", spec=sys)
+    def test_ctrl_c(self, m_sys, m_docker_client):
+        """
+        Test _attach_and_stream when a Keyboard interrupt is generated.
+
+        :return: None
+        """
+        # attach(..., stream=True) returns a generator.
+        def container_output_gen():
+            yield ("Some output\n")
+            yield ("from the container.")
+            raise KeyboardInterrupt()
+            yield ("This output is not printed.")
+
+        m_docker_client.attach.return_value = container_output_gen()
+        m_stdout = Mock(spec=sys.stdout)
+        m_sys.stdout = m_stdout
+        m_container = Mock()
+        _attach_and_stream(m_container)
+
+        m_docker_client.attach.assert_called_once_with(m_container,
+                                                       stream=True)
+        self.assertFalse(m_container.called)
+        m_stdout.write.assert_has_calls([call("Some output\n"),
+                                         call("from the container.")])
+        self.assertEqual(m_stdout.write.call_count, 2)
+        m_docker_client.stop.assert_called_once_with(m_container)
+
+    @patch("calico_ctl.node.docker_client", spec=Client)
+    @patch("calico_ctl.node.sys", spec=sys)
+    def test_killed(self, m_sys, m_docker_client):
+        """
+        Test _attach_and_stream when killed by another process.
+
+        :return: None
+        """
+        # attach(..., stream=True) returns a generator.
+        def container_output_gen():
+            yield ("Some output\n")
+            yield ("from the container.")
+            # Commit suicide, simulating being killed from another terminal.
+            os.kill(os.getpid(), signal.SIGTERM)
+            yield ("\nThis output is printed, but only because we nerf'd "
+                   "sys.exit()")
+
+        m_docker_client.attach.return_value = container_output_gen()
+        m_stdout = Mock(spec=sys.stdout)
+        m_sys.stdout = m_stdout
+        m_container = Mock()
+        _attach_and_stream(m_container)
+
+        m_docker_client.attach.assert_called_once_with(m_container,
+                                                       stream=True)
+        self.assertFalse(m_container.called)
+        m_sys.exit.assert_called_once_with(0)
+        m_stdout.write.assert_has_calls([call("Some output\n"),
+                                         call("from the container."),
+                                         call("\nThis output is printed, but "
+                                              "only because we nerf'd "
+                                              "sys.exit()")])
+
+        # Stop gets called twice, once for SIGTERM, and because sys.exit() gets
+        # mocked, the function continues and we get another call when the
+        # generator ends normally.
+        m_docker_client.stop.assert_has_calls([call(m_container),
+                                               call(m_container)])
+        self.assertEqual(m_docker_client.stop.call_count, 2)
+


### PR DESCRIPTION
This addition allows the Calico service to be more easily integrated with init systems, which start a process and monitor it.  In this case, calicoctl is that process, and shares fate with the calico-node container.
