### PR TITLE
Remove warning about sh.command logger

### DIFF
--- a/calico_containers/tests/st/test_base.py
+++ b/calico_containers/tests/st/test_base.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from subprocess import CalledProcessError
 import subprocess
 from unittest import TestCase
-import logging
 
 from tests.st.utils.utils import get_ip
 
-logging.getLogger('sh').setLevel('INFO')
 
 class TestBase(TestCase):
     """


### PR DESCRIPTION
Is this actually needed?

I get messages like this when running tests
```
nosetests calico_containers/tests/st/test_multi_host.py -sv --nologcapture --with-timer
Run a mainline multi-host test. ... No handlers could be found for logger "sh.command"
```