### PR TITLE
Allow containers to reach the host.

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -140,6 +140,14 @@ class DatastoreClient(object):
         else:
             self.etcd_client.write(host_path + "bgp_as", as_num)
 
+        # Configure Felix to allow traffic from the containers to the host (if
+        # not otherwise firewalled by the host administrator or profiles).
+        # This is important for Mesos, where the containerized executor process
+        # needs to exchange messages with the Mesos Slave process running on
+        # the host.
+        self.etcd_client.write(host_path +
+                               "config/DefaultEndpointToHostAction", "RETURN")
+
         # Flag to Felix that the host is created.
         self.etcd_client.write(host_path + "config/marker", "created")
 

--- a/calico_containers/tests/st/test_container_to_host.py
+++ b/calico_containers/tests/st/test_container_to_host.py
@@ -1,0 +1,39 @@
+from subprocess import CalledProcessError
+
+from test_base import TestBase
+from tests.st.utils.docker_host import DockerHost
+
+
+class TestContainerToHost(TestBase):
+    def test_container_to_host(self):
+        """
+        Test that a container can ping the host.  (Without using the docker
+        network driver, since it doesn't support that yet.)
+
+        This function is important for Mesos, since the containerized executor
+        needs to exchange messages with the Mesos Slave process on the host.
+        """
+        with DockerHost('host', dind=False) as host:
+            host.calicoctl("profile add TEST")
+
+            # Use standard docker bridge networking.
+            node1 = host.create_workload("node1")
+
+            # Add the nodes to Calico networking.
+            host.calicoctl("container add %s 192.168.100.1" % node1)
+
+            # Get the endpoint IDs for the containers
+            ep1 = host.calicoctl("container %s endpoint-id show" % node1)
+
+            # Now add the profiles.
+            host.calicoctl("endpoint %s profile set TEST" % ep1)
+
+            # Check it works.  Note that the profile allows all outgoing
+            # traffic by default, and conntrack should allow the reply.
+            node1.assert_can_ping(host.ip, retries=10)
+
+            # Test the teardown commands
+            host.calicoctl("profile remove TEST")
+            host.calicoctl("container remove %s" % node1)
+            host.calicoctl("pool remove 192.168.0.0/16")
+            host.calicoctl("node stop")

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -678,11 +678,14 @@ class TestDatastoreClient(unittest.TestCase):
         expected_writes = [call(TEST_HOST_PATH + "/bird_ip", bird_ip),
                            call(TEST_HOST_PATH + "/bird6_ip", bird6_ip),
                            call(TEST_HOST_PATH + "/bgp_as", bgp_as),
+                           call(TEST_HOST_PATH +
+                                "/config/DefaultEndpointToHostAction",
+                                "RETURN"),
                            call(TEST_HOST_PATH + "/config/marker",
                                 "created")]
         self.etcd_client.write.assert_has_calls(expected_writes,
                                                 any_order=True)
-        assert_equal(self.etcd_client.write.call_count, 4)
+        assert_equal(self.etcd_client.write.call_count, 5)
 
     def test_create_host_mainline(self):
         """
@@ -705,13 +708,16 @@ class TestDatastoreClient(unittest.TestCase):
         self.datastore.create_host(TEST_HOST, bird_ip, bird6_ip, bgp_as)
         expected_writes = [call(TEST_HOST_PATH + "/bird_ip", bird_ip),
                            call(TEST_HOST_PATH + "/bird6_ip", bird6_ip),
+                           call(TEST_HOST_PATH +
+                                "/config/DefaultEndpointToHostAction",
+                                "RETURN"),
                            call(TEST_HOST_PATH + "/config/marker",
                                 "created"),
                            call(TEST_HOST_PATH + "/workload",
                                 None, dir=True)]
         self.etcd_client.write.assert_has_calls(expected_writes,
                                                 any_order=True)
-        assert_equal(self.etcd_client.write.call_count, 4)
+        assert_equal(self.etcd_client.write.call_count, 5)
 
     def test_remove_host_mainline(self):
         """


### PR DESCRIPTION
Starting in Felix v0.25, the default behaviour is to prevent
endpoints from reaching thier local host IP.  However, this is
required for common containerized environments like Mesos,
where the containerized executor exchanges messages with a
Mesos Slave process on the host.

This change reverts Felix to the pre-0.25 behaviour by setting
a configuration field in etcd.

It also includes an ST for regression testing.