### PR TITLE
Network independent IP retrieval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ut: calicobuild.created
 	docker run --rm -v `pwd`/calico_containers:/code -u root \
 	calico/build bash -c \
 	'/tmp/etcd -data-dir=/tmp/default.etcd/ >/dev/null 2>&1 & \
-	nosetests tests/unit -c nose.cfg'
+	nosetests tests/unit pycalico/tests -c nose.cfg'
 
 ut-kubernetes: calicobuild.created
 	docker run --rm -v `pwd`/calico_containers:/code/calico_containers \

--- a/calico_containers/integrations/kubernetes/tests/kube_plugin_test.py
+++ b/calico_containers/integrations/kubernetes/tests/kube_plugin_test.py
@@ -123,21 +123,16 @@ class NetworkPluginTest(unittest.TestCase):
             self.assertEqual(return_val.endpoint_id, 'ep_id')
 
     def test_get_node_ip(self):
-        with patch('integrations.kubernetes.calico_kubernetes.socket.socket',
-                   autospec=True) as m_socket:
+        with patch('integrations.kubernetes.calico_kubernetes.get_host_ips',
+                   autospec=True) as m_get_host_ips:
             # Set up mock objects
-            m_socket_return = MagicMock()
-            m_socket_return.getsockname.return_value = ['1.2.3.4']
-            m_socket.return_value = m_socket_return
+            m_get_host_ips.return_value = ['1.2.3.4','4.2.3.4']
 
             # Call method under test
             return_val = self.plugin._get_node_ip()
 
             # Assert
-            m_socket.assert_called_once_with(socket.AF_INET, socket.SOCK_DGRAM)
-            m_socket_return.connect.assert_called_once_with(('8.8.8.8', 80))
-            m_socket_return.getsockname.assert_called_once_with()
-            m_socket_return.close.assert_called_once_with()
+            m_get_host_ips.assert_called_once_with(version=4)
             self.assertEqual(return_val, '1.2.3.4')
 
     def test_read_docker_ip(self):
@@ -246,7 +241,7 @@ class NetworkPluginTest(unittest.TestCase):
             m_get_api_path.return_value = pods
 
             # Set up class member
-            self.plugin.pod_name = 'pod_2'
+            self.plugin.pod_name = 'pod-2'
 
             # Call method under test
             return_val = self.plugin._get_pod_config()

--- a/calico_containers/pycalico/tests/test_util.py
+++ b/calico_containers/pycalico/tests/test_util.py
@@ -1,0 +1,124 @@
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from mock import patch, Mock
+from subprocess import CalledProcessError, check_output
+from pycalico.util import get_host_ips
+
+MOCK_IP_ADDR = \
+"""
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether 08:00:27:73:c8:d0 brd ff:ff:ff:ff:ff:ff
+    inet 172.24.114.18/24 brd 172.24.114.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 2620:104:4008:69:8d7c:499f:2f04:9e55/64 scope global temporary dynamic 
+       valid_lft 603690sec preferred_lft 84690sec
+    inet6 2620:104:4008:69:a00:27ff:fe73:c8d0/64 scope global dynamic 
+       valid_lft 604698sec preferred_lft 86298sec
+    inet6 fe80::a00:27ff:fe73:c8d0/64 scope link 
+       valid_lft forever preferred_lft forever
+3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+    link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
+    inet 172.17.42.1/24 scope global docker0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::188f:d6ff:fe1f:1482/64 scope link 
+       valid_lft forever preferred_lft forever
+"""
+
+MOCK_IP_ADDR_LOOPBACK = \
+"""
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 
+    inet6 ::1/128 scope host 
+       valid_lft forever preferred_lft forever
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+"""
+
+
+class TestUtil(unittest.TestCase):
+
+  @patch("pycalico.util.check_output", autospec=True)
+  def test_get_host_ips_standard(self, m_check_output):
+    # Test IPv4
+    m_check_output.return_value = MOCK_IP_ADDR
+    addrs = get_host_ips(version=4)
+    m_check_output.assert_called_once_with(["ip", "-4", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, ['172.24.114.18/24', '172.17.42.1/24'])
+
+    # Test IPv6
+    addrs = get_host_ips(version=6)
+    m_check_output.assert_called_once_with(["ip", "-6", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55/64',
+                  '2620:104:4008:69:a00:27ff:fe73:c8d0/64',
+                  'fe80::a00:27ff:fe73:c8d0/64',
+                  'fe80::188f:d6ff:fe1f:1482/64'])
+
+  @patch("pycalico.util.check_output", autospec=True)
+  def test_get_host_ips_loopback_only(self, m_check_output):
+    # Test Loopback
+    m_check_output.return_value = MOCK_IP_ADDR_LOOPBACK
+    addrs = get_host_ips(version=4)
+    m_check_output.assert_called_once_with(["ip", "-4", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, [])
+
+    addrs = get_host_ips(version=6)
+    m_check_output.assert_called_once_with(["ip", "-6", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, [])
+
+  @patch("pycalico.util.check_output", autospec=True)
+  def test_get_host_ips_exclude(self, m_check_output):
+    # Exclude "docker0"
+    m_check_output.return_value = MOCK_IP_ADDR
+    addrs = get_host_ips(version=4, exclude=["docker0"])
+    m_check_output.assert_called_once_with(["ip", "-4", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, ['172.24.114.18/24'])
+
+    addrs = get_host_ips(version=6, exclude=["docker0"])
+    m_check_output.assert_called_once_with(["ip", "-6", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55/64',
+                  '2620:104:4008:69:a00:27ff:fe73:c8d0/64',
+                  'fe80::a00:27ff:fe73:c8d0/64'])
+
+    # Exclude empty list
+    addrs = get_host_ips(version=4, exclude=[""])
+    m_check_output.assert_called_once_with(["ip", "-4", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, ['172.24.114.18/24', '172.17.42.1/24'])
+
+    addrs = get_host_ips(version=6, exclude=[""])
+    m_check_output.assert_called_once_with(["ip", "-6", "addr"])
+    m_check_output.reset_mock()
+    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55/64',
+                  '2620:104:4008:69:a00:27ff:fe73:c8d0/64',
+                  'fe80::a00:27ff:fe73:c8d0/64',
+                  'fe80::188f:d6ff:fe1f:1482/64'])
+
+  @patch("pycalico.util.check_output", autospec=True)
+  def test_get_host_ips_fail_check_output(self, m_check_output):
+    m_check_output.side_effect = CalledProcessError(returncode=1, cmd=check_output(["ip", "-4", "addr"]))
+    with self.assertRaises(SystemExit):
+        addrs = get_host_ips(version=4)

--- a/calico_containers/pycalico/util.py
+++ b/calico_containers/pycalico/util.py
@@ -1,3 +1,20 @@
+import sys
+import re
+from netaddr import IPNetwork, AddrFormatError
+from subprocess import check_output, CalledProcessError
+
+"""
+Compile Regexes
+"""
+# Splits into groups that start w/ no whitespace and contain all lines below that start w/ whitespace
+INTERFACE_SPLIT_RE = re.compile(r'(\d+:.*(?:\n\s+.*)+)')
+# Grabs interface name
+IFACE_RE = re.compile(r'^\d+: (\S+):')
+# Grabs v4 addresses
+IPV4_RE = re.compile(r'inet ((?:\d+\.){3}\d+\/\d+)')
+# Grabs v6 addresses
+IPV6_RE = re.compile(r'inet6 ?([a-fA-F:\./\d]+) ')
+
 def generate_cali_interface_name(prefix, ep_id):
     """Helper method to generate a name for a calico veth, given the endpoint ID
 
@@ -10,3 +27,44 @@ def generate_cali_interface_name(prefix, ep_id):
     if len(prefix) > 4:
         raise ValueError('Prefix must be 4 characters or less.')
     return prefix + ep_id[:11]
+
+
+def get_host_ips(version=4, exclude=None):
+    """
+    Gets all IP addresses assigned to this host.
+
+    Ignores Loopback Addresses
+
+    This function is fail-safe and will return an empty array instead of
+    raising any exceptions.
+
+    :param version: Desired version of IP addresses. Can be 4 or 6. defaults to 4
+    :param exclude: list of interfaces (strings) to ignore (ex. ["lo","docker0"])
+    :return: List of string representations of IP Addresses.
+    """
+    exclude = exclude or []
+    ip_addrs = []
+
+    # Select Regex for IPv6 or IPv4.
+    IP_RE = IPV4_RE if version is 4 else IPV6_RE
+
+    # Call `ip addr`.
+    try:
+        ip_addr_output = check_output(["ip", "-%d" % (version), "addr"])
+    except CalledProcessError, OSError:
+        print "Call to 'ip addr' Failed"
+        sys.exit(1)
+
+    # Separate interface blocks from ip addr output and iterate.
+    for iface_block in INTERFACE_SPLIT_RE.findall(ip_addr_output):
+        # Exclude certain interfaces.
+        match = IFACE_RE.match(iface_block)
+        if match and match.group(1) not in exclude:
+            # Iterate through Addresses on interface.
+            for address in IP_RE.findall(iface_block):
+                # Append non-loopback addresses.
+                if not IPNetwork(address).ip.is_loopback():
+                    ip_addrs.append(address)
+
+    return ip_addrs
+

--- a/calico_containers/tests/unit/calicoctl_test.py
+++ b/calico_containers/tests/unit/calicoctl_test.py
@@ -324,7 +324,7 @@ class TestNode(unittest.TestCase):
         m_os_path_exists.assert_called_once_with(log_dir)
         m_os_makedirs.assert_called_once_with(log_dir)
         m_check_system.assert_called_once_with(fix=False, quit_if_error=False)
-        m_get_host_ips.assert_called_once_with(4)
+        m_get_host_ips.assert_called_once_with(exclude=["docker0"])
         m_warn_if_unknown_ip.assert_called_once_with(ip_2, ip6)
         m_warn_if_hostname_conflict.assert_called_once_with(ip_2)
         m_install_kube.assert_called_once_with(node.KUBERNETES_PLUGIN_DIR)


### PR DESCRIPTION
Previous implementation of IP retrieval pings Google's DNS Server, this uses legacy RegEx formulas to  parse `ip addr` output