### PR TITLE
Convert felix-invalid "/" characters into "_" characters

### DIFF
--- a/calico_containers/integrations/kubernetes/calico_kubernetes.py
+++ b/calico_containers/integrations/kubernetes/calico_kubernetes.py
@@ -191,7 +191,7 @@ class NetworkPlugin(object):
 
         for pod in pods:
             print('Processing pod %s' % pod)
-            if pod['metadata']['name'].replace('-', '_') == self.pod_name:
+            if pod['metadata']['name'].replace('/', '_') == self.pod_name:
                 this_pod = pod
                 break
         else:
@@ -318,7 +318,7 @@ class NetworkPlugin(object):
 
         for k, v in labels.iteritems():
             tag = '%s_%s' % (k, v)
-            tag = tag.replace('-', '_')
+            tag = tag.replace('/', '_')
             print('Adding tag ' + tag)
             try:
                 calicoctl('profile', profile_name, 'tag', 'add', tag)
@@ -334,7 +334,7 @@ if __name__ == '__main__':
         print('No initialization work to perform')
     else:
         # These args only present for setup/teardown.
-        pod_name = sys.argv[3].replace('-', '_')
+        pod_name = sys.argv[3].replace('/', '_')
         docker_id = sys.argv[4]
         if mode == 'setup':
             print('Executing Calico pod-creation hook')


### PR DESCRIPTION
Replace forward-slash character with underscore to make kubernetes labels valid in Felix ip-tables rules. Also removed replacement of `-` characteres since Kubernetes now accepts them as valid characters.

In Kubernetes, label names are passed to Felix which use them as rule-names (for human readability). However, Kubernetes accepts the `/` character, which Felix will error on. Therefore, we need to encode the `/` character. 

This PR is a temporary fix which converts `/` to `_`, but will result in collisions if an identical chain-name is passed in where the character is replaced. For example, if Kubernetes creates `custom/rule` and then creates `custom_rule`, there will be an IP Tables error in calico. (Opening a seperate issue to come up with a better encoding)