### PR TITLE
Adjusted regex expression for IP Address

### DIFF
--- a/calico_containers/pycalico/tests/test_util.py
+++ b/calico_containers/pycalico/tests/test_util.py
@@ -62,16 +62,16 @@ class TestUtil(unittest.TestCase):
     addrs = get_host_ips(version=4)
     m_check_output.assert_called_once_with(["ip", "-4", "addr"])
     m_check_output.reset_mock()
-    self.assertEquals(addrs, ['172.24.114.18/24', '172.17.42.1/24'])
+    self.assertEquals(addrs, ['172.24.114.18', '172.17.42.1'])
 
     # Test IPv6
     addrs = get_host_ips(version=6)
     m_check_output.assert_called_once_with(["ip", "-6", "addr"])
     m_check_output.reset_mock()
-    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55/64',
-                  '2620:104:4008:69:a00:27ff:fe73:c8d0/64',
-                  'fe80::a00:27ff:fe73:c8d0/64',
-                  'fe80::188f:d6ff:fe1f:1482/64'])
+    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55',
+                  '2620:104:4008:69:a00:27ff:fe73:c8d0',
+                  'fe80::a00:27ff:fe73:c8d0',
+                  'fe80::188f:d6ff:fe1f:1482'])
 
   @patch("pycalico.util.check_output", autospec=True)
   def test_get_host_ips_loopback_only(self, m_check_output):
@@ -94,28 +94,28 @@ class TestUtil(unittest.TestCase):
     addrs = get_host_ips(version=4, exclude=["docker0"])
     m_check_output.assert_called_once_with(["ip", "-4", "addr"])
     m_check_output.reset_mock()
-    self.assertEquals(addrs, ['172.24.114.18/24'])
+    self.assertEquals(addrs, ['172.24.114.18'])
 
     addrs = get_host_ips(version=6, exclude=["docker0"])
     m_check_output.assert_called_once_with(["ip", "-6", "addr"])
     m_check_output.reset_mock()
-    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55/64',
-                  '2620:104:4008:69:a00:27ff:fe73:c8d0/64',
-                  'fe80::a00:27ff:fe73:c8d0/64'])
+    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55',
+                  '2620:104:4008:69:a00:27ff:fe73:c8d0',
+                  'fe80::a00:27ff:fe73:c8d0'])
 
     # Exclude empty list
     addrs = get_host_ips(version=4, exclude=[""])
     m_check_output.assert_called_once_with(["ip", "-4", "addr"])
     m_check_output.reset_mock()
-    self.assertEquals(addrs, ['172.24.114.18/24', '172.17.42.1/24'])
+    self.assertEquals(addrs, ['172.24.114.18', '172.17.42.1'])
 
     addrs = get_host_ips(version=6, exclude=[""])
     m_check_output.assert_called_once_with(["ip", "-6", "addr"])
     m_check_output.reset_mock()
-    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55/64',
-                  '2620:104:4008:69:a00:27ff:fe73:c8d0/64',
-                  'fe80::a00:27ff:fe73:c8d0/64',
-                  'fe80::188f:d6ff:fe1f:1482/64'])
+    self.assertEquals(addrs, ['2620:104:4008:69:8d7c:499f:2f04:9e55',
+                  '2620:104:4008:69:a00:27ff:fe73:c8d0',
+                  'fe80::a00:27ff:fe73:c8d0',
+                  'fe80::188f:d6ff:fe1f:1482'])
 
   @patch("pycalico.util.check_output", autospec=True)
   def test_get_host_ips_fail_check_output(self, m_check_output):

--- a/calico_containers/pycalico/util.py
+++ b/calico_containers/pycalico/util.py
@@ -11,9 +11,9 @@ INTERFACE_SPLIT_RE = re.compile(r'(\d+:.*(?:\n\s+.*)+)')
 # Grabs interface name
 IFACE_RE = re.compile(r'^\d+: (\S+):')
 # Grabs v4 addresses
-IPV4_RE = re.compile(r'inet ((?:\d+\.){3}\d+\/\d+)')
+IPV4_RE = re.compile(r'inet ((?:\d+\.){3}\d+)\/\d+')
 # Grabs v6 addresses
-IPV6_RE = re.compile(r'inet6 ?([a-fA-F:\./\d]+) ')
+IPV6_RE = re.compile(r'inet6 ([a-fA-F\d:]+)\/\d{1,3}')
 
 def generate_cali_interface_name(prefix, ep_id):
     """Helper method to generate a name for a calico veth, given the endpoint ID


### PR DESCRIPTION
Python regex expression was grouping the subnet with the IP Address. Adjusted the parenthesis to confirm that a subnet is present but only return the IP address