### PR TITLE
Converted calico_ctl into its own package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     keywords='calico docker etcd mesos kubernetes rkt openstack',
 
     package_dir={"": "calico_containers"},
-    packages=["pycalico"],
+    packages=["pycalico", "calico_ctl"],
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
Now, when calico-docker repo is installed with pip, in addition to getting a pycalico package, they will get a calico_ctl package. This is a current requirement by the kubernetes plugin, and will most likely be used by other packages in the future.