### PR TITLE
Add start of day checking of etcd authority value.

### DIFF
--- a/calico_containers/calico_ctl/bgp.py
+++ b/calico_containers/calico_ctl/bgp.py
@@ -29,10 +29,12 @@ Options:
  --ipv6    Show IPv6 information only.
 """
 import sys
-from utils import client
+
 from pycalico.datastore_datatypes import BGPPeer
 from netaddr import IPAddress
 from prettytable import PrettyTable
+
+from connectors import client
 from utils import get_container_ipv_from_arguments
 from utils import validate_ip
 

--- a/calico_containers/calico_ctl/checksystem.py
+++ b/calico_containers/calico_ctl/checksystem.py
@@ -24,12 +24,14 @@ Options:
 import sys
 import re
 import sh
+
 import docker
 from requests import ConnectionError
+
 from utils import DOCKER_VERSION
 from utils import enforce_root
 from utils import sysctl
-from utils import docker_client
+from connectors import docker_client
 
 def checksystem(arguments):
     """

--- a/calico_containers/calico_ctl/connectors.py
+++ b/calico_containers/calico_ctl/connectors.py
@@ -1,0 +1,39 @@
+# Copyright 2015 Metaswitch Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+import docker
+import docker.errors
+
+from pycalico.ipam import IPAMClient
+from pycalico.datastore import ETCD_AUTHORITY_ENV
+
+from utils import DOCKER_VERSION
+from utils import print_paragraph
+from utils import validate_hostname_port
+
+# If an ETCD_AUTHORITY is specified in the environment variables, validate
+# it.
+etcd_authority = os.getenv(ETCD_AUTHORITY_ENV, None)
+if etcd_authority and not validate_hostname_port(etcd_authority):
+    print_paragraph("Invalid %s. It must take the form <address>:<port>. "
+                    "Value provided is '%s'" % (ETCD_AUTHORITY_ENV,
+                                                etcd_authority))
+    sys.exit(1)
+
+client = IPAMClient()
+
+_base_url=os.getenv("DOCKER_HOST", "unix://var/run/docker.sock")
+docker_client = docker.Client(version=DOCKER_VERSION,
+                               base_url=_base_url)

--- a/calico_containers/calico_ctl/container.py
+++ b/calico_containers/calico_ctl/container.py
@@ -20,14 +20,14 @@ from requests.exceptions import ConnectionError
 from urllib3.exceptions import MaxRetryError
 from subprocess import CalledProcessError
 from netaddr import IPAddress, IPNetwork
-
 from pycalico import netns
 from pycalico.datastore_datatypes import Endpoint
+
+from connectors import client
+from connectors import docker_client
 from utils import hostname, ORCHESTRATOR_ID
-from utils import client
 from utils import enforce_root
 from utils import get_container_ipv_from_arguments
-from utils import docker_client
 from utils import print_paragraph
 from utils import validate_ip
 

--- a/calico_containers/calico_ctl/diags.py
+++ b/calico_containers/calico_ctl/diags.py
@@ -30,9 +30,12 @@ import tarfile
 import socket
 import tempfile
 import subprocess
+
 from etcd import EtcdException
-from shutil import copytree, ignore_patterns
 from pycalico.datastore import DatastoreClient
+from shutil import copytree, ignore_patterns
+
+from utils import print_paragraph
 
 
 def diags(arguments):
@@ -57,7 +60,8 @@ def save_diags(log_dir, upload=False):
 
     # Write date to file
     with open(os.path.join(temp_diags_dir, 'date'), 'w') as f:
-        f.write("DATE=%s" % datetime.strftime(datetime.today(),"%Y-%m-%d_%H-%M-%S"))
+        f.write("DATE=%s" % datetime.strftime(datetime.today(),
+                                              "%Y-%m-%d_%H-%M-%S"))
 
     # Write hostname to file
     with open(os.path.join(temp_diags_dir, 'hostname'), 'w') as f:
@@ -140,7 +144,8 @@ def save_diags(log_dir, upload=False):
     # TODO: May want to move this into datastore.py as a dump-calico function
     try:
         datastore_client = DatastoreClient()
-        datastore_data = datastore_client.etcd_client.read("/calico", recursive=True)
+        datastore_data = datastore_client.etcd_client.read("/calico",
+                                                           recursive=True)
         with open(os.path.join(temp_diags_dir, 'etcd_calico'), 'w') as f:
             f.write("dir?, key, value\n")
             # TODO: python-etcd bug: Leaves show up twice in get_subtree().
@@ -153,7 +158,8 @@ def save_diags(log_dir, upload=False):
         print "Unable to dump etcd datastore"
 
     # Create tar and upload
-    tar_filename = datetime.strftime(datetime.today(),"diags-%d%m%y_%H%M%S.tar.gz")
+    tar_filename = datetime.strftime(datetime.today(),
+                                     "diags-%d%m%y_%H%M%S.tar.gz")
     full_tar_path = os.path.join(temp_dir, tar_filename)
     with tarfile.open(full_tar_path, "w:gz") as tar:
         # pass in arcname, otherwise zip contains layers of subfolders
@@ -167,8 +173,11 @@ def save_diags(log_dir, upload=False):
 
 def upload_temp_diags(diags_path):
     # TODO: Rewrite into httplib
-    print("Uploading file. Available for 14 days from the URL printed when the upload completes")
-    curl_cmd = ["curl", "--upload-file", diags_path, os.path.join("https://transfer.sh", os.path.basename(diags_path))]
+    print_paragraph("Uploading file. Available for 14 days from the URL "
+                    "printed when the upload completes")
+    curl_cmd = ["curl", "--upload-file", diags_path,
+                os.path.join("https://transfer.sh",
+                             os.path.basename(diags_path))]
     curl_process = subprocess.Popen(curl_cmd)
     curl_process.communicate()
     curl_process.wait()

--- a/calico_containers/calico_ctl/endpoint.py
+++ b/calico_containers/calico_ctl/endpoint.py
@@ -40,11 +40,13 @@ Examples:
 """
 import sys
 from collections import defaultdict
+
 from prettytable import PrettyTable
 from pycalico.datastore_errors import ProfileAlreadyInEndpoint
 from pycalico.datastore_errors import MultipleEndpointsMatch
 from pycalico.datastore_errors import ProfileNotInEndpoint
-from utils import client
+
+from connectors import client
 from utils import print_paragraph
 from utils import validate_characters
 

--- a/calico_containers/calico_ctl/pool.py
+++ b/calico_containers/calico_ctl/pool.py
@@ -27,11 +27,14 @@ Options:
   --ipip          Use IP-over-IP encapsulation across hosts
  """
 import sys
+
 import netaddr
 from netaddr import IPNetwork, IPRange, IPAddress
 from prettytable import PrettyTable
 from pycalico.datastore_datatypes import IPPool
-from utils import (validate_cidr, validate_ip, client,
+
+from connectors import client
+from utils import (validate_cidr, validate_ip,
                    get_container_ipv_from_arguments)
 
 

--- a/calico_containers/calico_ctl/profile.py
+++ b/calico_containers/calico_ctl/profile.py
@@ -60,10 +60,12 @@ Examples:
 """
 import sys
 import re
+
 from prettytable import PrettyTable
 from pycalico.datastore import Rule
 from pycalico.datastore import Rules
-from utils import client
+
+from connectors import client
 from utils import print_paragraph
 from utils import validate_characters
 from utils import validate_cidr

--- a/calico_containers/calico_ctl/status.py
+++ b/calico_containers/calico_ctl/status.py
@@ -20,8 +20,10 @@ Description:
   and the BIRD routing daemon.
 """
 import re
-from utils import docker_client
+
 from prettytable import PrettyTable
+
+from connectors import docker_client
 
 
 def status(arguments):
@@ -42,9 +44,11 @@ def status(arguments):
         print "calico-node container is running. Status: %s" % \
               calico_node_info[0]["Status"]
 
-        apt_cmd = docker_client.exec_create("calico-node", ["/bin/bash", "-c",
-                                           "apt-cache policy calico-felix"])
-        result = re.search(r"Installed: (.*?)\s", docker_client.exec_start(apt_cmd))
+        apt_cmd = docker_client.exec_create("calico-node",
+                                           ["/bin/bash", "-c",
+                                            "apt-cache policy calico-felix"])
+        result = re.search(r"Installed: (.*?)\s",
+                           docker_client.exec_start(apt_cmd))
         if result is not None:
             print "Running felix version %s" % result.group(1)
 
@@ -52,6 +56,7 @@ def status(arguments):
         pprint_bird_protocols(4)
         print "IPv6 BGP status"
         pprint_bird_protocols(6)
+
 
 def pprint_bird_protocols(version):
     """

--- a/calico_containers/calicoctl.py
+++ b/calico_containers/calicoctl.py
@@ -33,8 +33,10 @@ Usage: calicoctl <command> [<args>...]
 
 See 'calicoctl <command> --help' to read about a specific subcommand.
 """
+import os
 import sys
 import traceback
+
 from docopt import docopt
 from pycalico.datastore_errors import DataStoreError
 

--- a/calico_containers/nose.cfg
+++ b/calico_containers/nose.cfg
@@ -1,4 +1,4 @@
 [nosetests]
 with-coverage=1
 cover-erase=1
-cover-package=pycalico,calico_ctl,libnetwork_plugin
+cover-package=calico_ctl,libnetwork_plugin

--- a/calico_containers/tests/unit/calicoctl_test.py
+++ b/calico_containers/tests/unit/calicoctl_test.py
@@ -17,7 +17,6 @@ from requests import Response
 from StringIO import StringIO
 from mock import patch, Mock, call
 from nose_parameterized import parameterized
-from netaddr import IPAddress
 from docker.errors import APIError
 from calico_ctl.bgp import *
 from calico_ctl.bgp import validate_arguments as bgp_validate_arguments
@@ -28,7 +27,8 @@ from calico_ctl.pool import validate_arguments as pool_validate_arguments
 from calico_ctl.profile import validate_arguments as profile_validate_arguments
 from calico_ctl.container import validate_arguments as container_validate_arguments
 from calico_ctl.container import container_add
-from calico_ctl.utils import validate_cidr, validate_ip, validate_characters
+from calico_ctl.utils import (validate_cidr, validate_ip, validate_characters,
+                              validate_hostname_port)
 from pycalico.datastore_datatypes import BGPPeer
 from pycalico.datastore import (ETCD_AUTHORITY_ENV,
                                 ETCD_AUTHORITY_DEFAULT)
@@ -208,6 +208,7 @@ class TestContainer(unittest.TestCase):
         m_info.assert_called_once_with(name)
         m_sys.exit.assert_called_once_with(1)
 
+
 class TestEndpoint(unittest.TestCase):
 
     @parameterized.expand([
@@ -349,7 +350,7 @@ class TestNode(unittest.TestCase):
             binds=binds
         )
         m_find_or_pull_node_image.assert_called_once_with(
-            'node_image', m_docker_client
+            'node_image'
         )
         m_docker_client.create_container.assert_called_once_with(
             node_image,
@@ -363,43 +364,6 @@ class TestNode(unittest.TestCase):
         )
         m_docker_client.start.assert_called_once_with(container)
         m_attach_and_stream.assert_called_once_with(container)
-
-    @patch('sys.exit', autospec=True)
-    @patch('os.path.exists', autospec=True)
-    @patch('os.makedirs', autospec=True)
-    @patch('os.getenv', autospec=True)
-    @patch('calico_ctl.node.check_system', autospec=True)
-    @patch('calico_ctl.node.get_host_ips', autospec=True)
-    @patch('calico_ctl.node.warn_if_unknown_ip', autospec=True)
-    @patch('calico_ctl.node.warn_if_hostname_conflict', autospec=True)
-    @patch('calico_ctl.node.install_kubernetes', autospec=True)
-    @patch('calico_ctl.node.client', autospec=True)
-    @patch('calico_ctl.node.docker_client', autospec=True)
-    def test_node_start_invalid_etcd_authority(
-            self, m_docker_client, m_client, m_install_kube, m_warn_if_hostname_conflict,
-            m_warn_if_unknown_ip, m_get_host_ips, m_check_system,
-            m_os_getenv, m_os_makedirs, m_os_path_exists, m_sys_exit):
-        """
-        Test that node_start exits when given a bad etcd authority ip:port
-        """
-        # Set up mock objects
-        m_os_getenv.return_value = '1.1.1.1:80:100'
-
-        # Set up arguments
-        node_image = 'node_image'
-        log_dir = './log_dir'
-        ip = ''
-        ip6 = 'aa:bb::zz'
-        as_num = ''
-        detach = False
-        kubernetes = True
-
-        # Call method under test
-        node.node_start(
-            node_image, log_dir, ip, ip6, as_num, detach, kubernetes
-        )
-
-        m_sys_exit.assert_called_once_with(1)
 
     @patch('os.path.exists', autospec=True)
     @patch('os.makedirs', autospec=True)
@@ -708,6 +672,42 @@ class TestUtils(unittest.TestCase):
 
             # Assert expected result
             self.assertEqual(expected_result, test_result)
+
+
+    @parameterized.expand([
+        ('1.2.3.4', False),
+        ('abcde', False),
+        ('aa:bb::cc:1234', False),
+        ('aa::256', False),
+        ('aa...bb:256', False),
+        ('aa:256', True),
+        ('1.2.3.244:256', True),
+        ('1.2.a.244:256', True),
+        ('-asr:100', False),
+        ('asr-:100', False),
+        ('asr-temp-test.thr.yes-33:100', True),
+        ('asr-temp-test.-thr.yes-33:100', False),
+        ('asr-temp-test.thr-.yes-33:100', False),
+        ('asr-temp-test.thr-.yes-33:100', False),
+        ('validhostname:0', False),
+        ('validhostname:65536', False),
+        ('validhostname:1', True),
+        ('validhostname:65535', True),
+        ('#notvalidhostname:65535', False),
+        ('verylong' * 100 + ':200', False),
+        ('12.256.122.43:aaa', False)
+    ])
+    def test_validate_hostname_port(self, input_string, expected_result):
+        """
+        Test validate_hostname_port function.
+
+        This also tests validate_hostname which is invoked from
+        validate_hostname_port.
+        """
+        test_result = validate_hostname_port(input_string)
+
+        # Assert expected result
+        self.assertEqual(expected_result, test_result)
 
 
 class SysExitMock(Exception):


### PR DESCRIPTION
Fixes #361 

Unit tests are not yet fixed up - worth reviewing general strategy before spending time on UTs.

Despite the extensive changes, the actual change is logically small:
-  Add some checking of ETCD_AUTHORITY in the calicoctl code
-  Make client and docker_client methods rather than statically initialized connections (the fact that they were statically initialised made the checking of the authority rather skanky .. it too had to be done in static initialization code, and sys exiting from that doesn't feel right).   The bulk of the change was therefore to change client.method() to client().method().