### PR TITLE
Updated doc hostname references to ip address equivalents

### DIFF
--- a/docs/getting-started/AWS.md
+++ b/docs/getting-started/AWS.md
@@ -95,7 +95,7 @@ aws ec2 run-instances \
 
 replacing <PATH_TO_CLOUD_CONFIG> with the appropriate directory containing the cloud config.
 
-Find the PrivateIpAddress value of the first server by checking the output of this command.  Open your `user-data-others` file and replace the instances of `calico-01` with this private IP address.
+Find the PrivateIpAddress value of the first server by checking the output of this command.  Open your `user-data-others` file and replace the instances of `172.17.8.101` with this private IP address.
 
 Now, for the second server run:
 

--- a/docs/getting-started/DigitalOcean.md
+++ b/docs/getting-started/DigitalOcean.md
@@ -46,7 +46,7 @@ address.
 Repeat this process for a second host `calico-02`, but this time use the
 cloud config from `user-data-other`, making the following global changes before
 pasting it in:
-- Replace all instances of calico-01 with the private IPv4 address of calico-01
+- Replace all instances of `172.17.8.101` with the private IPv4 address of `calico-01`.
 
 
 ## Set up the IP Pool before running the demo

--- a/docs/getting-started/GCE.md
+++ b/docs/getting-started/GCE.md
@@ -63,7 +63,9 @@ gcloud compute instances create \
   --metadata-from-file user-data=<PATH_TO_CLOUD_CONFIG>/user-data-first
 ```
 
-For the second server run:
+Open your `user-data-others` file and replace the instances of `172.17.8.101` with the private IP address of the `calico-01` server you just created.  You can find this in the output of the previous command.
+
+Then, for the second server, run:
 
 ```
 gcloud compute instances create \

--- a/docs/getting-started/VagrantCoreOS.md
+++ b/docs/getting-started/VagrantCoreOS.md
@@ -52,11 +52,11 @@ At this point, it's worth checking that your servers can ping each other.
 
 From calico-01
 
-    ping calico-02
+    ping 172.17.8.102
 
 From calico-02
 
-    ping calico-01
+    ping 172.17.8.101
 
 If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should 
 check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also 

--- a/docs/getting-started/VagrantUbuntu.md
+++ b/docs/getting-started/VagrantUbuntu.md
@@ -52,11 +52,11 @@ At this point, it's worth checking that your servers can ping each other.
 
 From calico-1
 
-    ping calico-02
+    ping 172.17.8.102
 
 From calico-2
 
-    ping calico-01
+    ping 172.17.8.101
 
 If you see ping failures, the likely culprit is a problem with the VirtualBox network between the VMs.  You should 
 check that each host is connected to the same virtual network adapter in VirtualBox and rebooting the host may also 

--- a/docs/getting-started/default-networking/cloud-config/user-data-others
+++ b/docs/getting-started/default-networking/cloud-config/user-data-others
@@ -5,7 +5,7 @@ coreos:
     reboot-strategy: 'off'
   fleet:
     public-ip: $public_ipv4
-    etcd_servers: http://calico-01:4001
+    etcd_servers: http://172.17.8.101:4001
   units:
   - name: fleet.service
     command: start
@@ -33,7 +33,7 @@ write_files:
     mkdir -p /opt/bin
     rm /home/core/.bashrc
     echo 'PATH=/opt/bin:$PATH' > /home/core/.bashrc
-    echo 'export ETCD_AUTHORITY="calico-01:4001"' >> /home/core/.bashrc
+    echo 'export ETCD_AUTHORITY="172.17.8.101:4001"' >> /home/core/.bashrc
     echo 'Defaults env_keep +="ETCD_AUTHORITY"' >>/etc/sudoers.d/etcd
 - path: /home/core/get_calicoctl.sh
   permissions: 777

--- a/docs/getting-started/libnetwork/cloud-config/user-data-others
+++ b/docs/getting-started/libnetwork/cloud-config/user-data-others
@@ -5,7 +5,7 @@ coreos:
     reboot-strategy: 'off'
   fleet:
     public-ip: $public_ipv4
-    etcd_servers: http://calico-01:4001
+    etcd_servers: http://172.17.8.101:4001
   units:
   - name: fleet.service
     command: start
@@ -47,7 +47,7 @@ coreos:
       MountFlags=slave
       LimitNOFILE=1048576
       LimitNPROC=1048576
-      ExecStart=/opt/bin/docker --kv-store=consul:calico-01:8500 --daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
+      ExecStart=/opt/bin/docker --kv-store=consul:172.17.8.101:8500 --daemon --host=fd:// $DOCKER_OPTS $DOCKER_OPT_BIP $DOCKER_OPT_MTU $DOCKER_OPT_IPMASQ
       ExecStartPost=/opt/bin/calicoctl checksystem --fix
       RestartSec=10
       Restart=always
@@ -65,7 +65,7 @@ write_files:
     mkdir -p /opt/bin
     rm /home/core/.bashrc
     echo 'PATH=/opt/bin:$PATH' > /home/core/.bashrc
-    echo 'export ETCD_AUTHORITY="calico-01:4001"' >> /home/core/.bashrc
+    echo 'export ETCD_AUTHORITY="172.17.8.101:4001"' >> /home/core/.bashrc
     echo 'Defaults env_keep +="ETCD_AUTHORITY"' >>/etc/sudoers.d/etcd
 - path: /home/core/get_experimental_docker.sh
   permissions: 777

--- a/docs/getting-started/powerstrip/cloud-config/user-data-others
+++ b/docs/getting-started/powerstrip/cloud-config/user-data-others
@@ -5,7 +5,7 @@ coreos:
     reboot-strategy: 'off'
   fleet:
     public-ip: $public_ipv4
-    etcd_servers: http://calico-01:4001
+    etcd_servers: http://172.17.8.101:4001
   units:
   - name: fleet.service
     command: start
@@ -33,7 +33,7 @@ write_files:
     mkdir -p /opt/bin
     rm /home/core/.bashrc
     echo 'PATH=/opt/bin:$PATH' > /home/core/.bashrc
-    echo 'export ETCD_AUTHORITY="calico-01:4001"' >> /home/core/.bashrc
+    echo 'export ETCD_AUTHORITY="172.17.8.101:4001"' >> /home/core/.bashrc
     echo 'Defaults env_keep +="ETCD_AUTHORITY"' >>/etc/sudoers.d/etcd
 - path: /home/core/get_calicoctl.sh
   permissions: 777


### PR DESCRIPTION
Replace instances of calico-01 and calico-02 when referencing hostnames with 172.17.8.101 and 172.17.8.102, respectively.
